### PR TITLE
[#24] diaryDate, emotion 필드 WateringCan으로 이동

### DIFF
--- a/src/main/java/umc/plantory/domain/wateringCan/entity/WateringCan.java
+++ b/src/main/java/umc/plantory/domain/wateringCan/entity/WateringCan.java
@@ -5,6 +5,9 @@ import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import umc.plantory.domain.diary.entity.Diary;
+import umc.plantory.global.enums.Emotion;
+
+import java.time.LocalDate;
 
 @Entity
 @Table(name = "watering_can")
@@ -23,4 +26,11 @@ public class WateringCan {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "diary_id")
     private Diary diary;
+
+    @Column(nullable = false)
+    private LocalDate diaryDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private Emotion emotion;
 }

--- a/src/main/java/umc/plantory/domain/wateringCan/entity/WateringEvent.java
+++ b/src/main/java/umc/plantory/domain/wateringCan/entity/WateringEvent.java
@@ -5,9 +5,6 @@ import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import umc.plantory.domain.terrarium.entity.Terrarium;
-import umc.plantory.global.enums.Emotion;
-
-import java.time.LocalDate;
 
 @Entity
 @Table(name = "watering_event")
@@ -30,12 +27,4 @@ public class WateringEvent {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "watering_can_id")
     private WateringCan wateringCan;
-
-    @Column(nullable = false)
-    private LocalDate diaryDate;
-
-    @Enumerated(EnumType.STRING)
-    @Column(length = 20, nullable = false)
-    private Emotion emotion;
-
 }


### PR DESCRIPTION
## 📖 1. 변경 사항 요약
- WateringEvent에 있던 `diaryDate`, `emotion` 필드를 WateringCan 엔티티로 이동

## 🔗 2. 관련 이슈
- Closes #24 

## 🛠 3. 구현 내용 및 상세
- 일기가 영구 삭제된 경우에도 물뿌리개 유지 + 해당 일기에 대한 날짜 및 감정 정보를 보존하기 위해, WateringEvent에 존재하던 `diaryDate`, `emotion` 필드를 WateringCan 엔티티로 이동하였습니다.
