### PR TITLE
[#26] 유저 회원가입 추가정보 입력 API 구현

### DIFF
--- a/src/main/java/umc/plantory/domain/member/controller/MemberRestController.java
+++ b/src/main/java/umc/plantory/domain/member/controller/MemberRestController.java
@@ -1,0 +1,24 @@
+package umc.plantory.domain.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.plantory.domain.member.dto.MemberRequestDTO;
+import umc.plantory.domain.member.dto.MemberResponseDTO;
+import umc.plantory.domain.member.service.MemberCommandService;
+import umc.plantory.global.apiPayload.ApiResponse;
+
+@RestController
+@RequestMapping("/v1/plantory/member")
+@RequiredArgsConstructor
+public class MemberRestController {
+    private final MemberCommandService memberCommandService;
+
+    @PatchMapping("/signup")
+    public ResponseEntity<ApiResponse<MemberResponseDTO.MemberSignupResponse>> signup(@RequestBody MemberRequestDTO.MemberSignupRequest request) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(memberCommandService.memberSignup(request)));
+    }
+}

--- a/src/main/java/umc/plantory/domain/member/converter/MemberConverter.java
+++ b/src/main/java/umc/plantory/domain/member/converter/MemberConverter.java
@@ -1,0 +1,25 @@
+package umc.plantory.domain.member.converter;
+
+import umc.plantory.domain.member.dto.MemberResponseDTO;
+import umc.plantory.domain.member.entity.Member;
+import umc.plantory.domain.member.mapping.MemberTerm;
+import umc.plantory.domain.term.entity.Term;
+
+public class MemberConverter {
+    private static final String tempNickname = "새싹이";
+    private static final String defaultProfileImg = "";
+
+    public static MemberResponseDTO.MemberSignupResponse toMemberSignupResponse(Member member) {
+        return MemberResponseDTO.MemberSignupResponse.builder()
+                .memberId(member.getId())
+                .build();
+    }
+
+    public static MemberTerm toMemberTerm(Member member, Term term, Boolean isAgree) {
+        return MemberTerm.builder()
+                .member(member)
+                .term(term)
+                .isAgree(isAgree)
+                .build();
+    }
+}

--- a/src/main/java/umc/plantory/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/umc/plantory/domain/member/dto/MemberRequestDTO.java
@@ -1,0 +1,32 @@
+package umc.plantory.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.plantory.global.enums.Gender;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class MemberRequestDTO {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class MemberSignupRequest {
+        private Long memberId;
+
+        private String nickname;
+
+        private String userCustomId;
+
+        private Gender gender;
+
+        private LocalDate birth;
+
+        private List<Long> agreeTermIdList;
+
+        private List<Long> disagreeTermIdList;
+    }
+}

--- a/src/main/java/umc/plantory/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/plantory/domain/member/dto/MemberResponseDTO.java
@@ -1,0 +1,16 @@
+package umc.plantory.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MemberResponseDTO {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class MemberSignupResponse {
+        private Long memberId;
+    }
+}

--- a/src/main/java/umc/plantory/domain/member/entity/Member.java
+++ b/src/main/java/umc/plantory/domain/member/entity/Member.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import umc.plantory.global.baseEntity.BaseEntity;
+import umc.plantory.global.enums.Gender;
 import umc.plantory.global.enums.MemberRole;
 import umc.plantory.global.enums.MemberStatus;
 import umc.plantory.global.enums.Provider;
@@ -28,6 +29,9 @@ public class Member extends BaseEntity {
 
     @Column(length = 10, nullable = false)
     private String name;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
 
     @Column(length = 25, nullable = false, unique = true)
     private String nickname;
@@ -80,4 +84,19 @@ public class Member extends BaseEntity {
     @ColumnDefault("0")
     private Integer totalBloomCnt;
 
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateUserCustomId(String userCustomId) {
+        this.userId = userCustomId;
+    }
+
+    public void updateBirth(LocalDate birth) {
+        this.birth = birth;
+    }
+
+    public void updateGender(Gender gender) {
+        this.gender = gender;
+    }
 }

--- a/src/main/java/umc/plantory/domain/member/mapping/MemberTerm.java
+++ b/src/main/java/umc/plantory/domain/member/mapping/MemberTerm.java
@@ -33,4 +33,8 @@ public class MemberTerm extends BaseEntity {
     @Column(nullable = false)
     @ColumnDefault("false")
     private Boolean isAgree;
+
+    public void updateIsAgree(boolean isAgree) {
+        this.isAgree = isAgree;
+    }
 }

--- a/src/main/java/umc/plantory/domain/member/repository/MemberRepository.java
+++ b/src/main/java/umc/plantory/domain/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package umc.plantory.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.plantory.domain.member.entity.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/umc/plantory/domain/member/repository/MemberTermRepository.java
+++ b/src/main/java/umc/plantory/domain/member/repository/MemberTermRepository.java
@@ -1,0 +1,13 @@
+package umc.plantory.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.plantory.domain.member.entity.Member;
+import umc.plantory.domain.member.mapping.MemberTerm;
+import umc.plantory.domain.term.entity.Term;
+
+import java.util.Optional;
+
+public interface MemberTermRepository extends JpaRepository<MemberTerm, Long> {
+    // 특정 약관 및 유저의 동의 상태 조회
+    Optional<MemberTerm> findByMemberAndTerm(Member member, Term term);
+}

--- a/src/main/java/umc/plantory/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/plantory/domain/member/service/MemberCommandService.java
@@ -1,0 +1,102 @@
+package umc.plantory.domain.member.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.plantory.domain.member.converter.MemberConverter;
+import umc.plantory.domain.member.dto.MemberRequestDTO;
+import umc.plantory.domain.member.dto.MemberResponseDTO;
+import umc.plantory.domain.member.entity.Member;
+import umc.plantory.domain.member.mapping.MemberTerm;
+import umc.plantory.domain.member.repository.MemberRepository;
+import umc.plantory.domain.member.repository.MemberTermRepository;
+import umc.plantory.domain.term.repository.TermRepository;
+import umc.plantory.global.apiPayload.code.status.ErrorStatus;
+import umc.plantory.global.apiPayload.exception.handler.MemberHandler;
+import umc.plantory.global.apiPayload.exception.handler.TermHandler;
+
+import java.util.List;
+import umc.plantory.domain.term.entity.Term;
+
+@Service
+@RequiredArgsConstructor
+public class MemberCommandService implements MemberCommandUseCase{
+    private final MemberRepository memberRepository;
+    private final MemberTermRepository memberTermRepository;
+    private final TermRepository termRepository;
+
+    @Override
+    @Transactional
+    public MemberResponseDTO.MemberSignupResponse memberSignup(MemberRequestDTO.MemberSignupRequest request) {
+        // 회원 조회
+        Member findMember = memberRepository.findById(request.getMemberId())
+            .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 필수 추가 정보 검증
+        if (!validateAdditionalInfo(request)) {
+            throw new MemberHandler(ErrorStatus.INVALID_MEMBER_INFO);
+        }
+
+        // 추가 정보 저장
+        findMember.updateNickname(request.getNickname());
+        findMember.updateUserCustomId(request.getUserCustomId());
+        findMember.updateBirth(request.getBirth());
+        findMember.updateGender(request.getGender());
+        memberRepository.save(findMember);
+
+        // 약관 동의 정보 저장
+        List<Long> agreeTermIdList = request.getAgreeTermIdList();
+        List<Long> disagreeTermIdList = request.getDisagreeTermIdList();
+        if (!validateRequiredTerms(agreeTermIdList)) {
+            throw new TermHandler(ErrorStatus.REQUIRED_TERM_NOT_AGREED);
+        }
+        // 동의한 약관
+        for (Long termId : agreeTermIdList) {
+            var term = termRepository.findById(termId)
+                .orElseThrow(() -> new TermHandler(ErrorStatus.TERM_NOT_FOUND));
+            memberTermRepository.findByMemberAndTerm(findMember, term)
+                .ifPresentOrElse(
+                    mt -> mt.updateIsAgree(true),
+                    () -> {
+                        MemberTerm newMemberTerm = MemberConverter.toMemberTerm(findMember, term, true);
+                        memberTermRepository.save(newMemberTerm);
+                    }
+                );
+        }
+        // 미동의한 약관
+        for (Long termId : disagreeTermIdList) {
+            var term = termRepository.findById(termId)
+                .orElseThrow(() -> new TermHandler(ErrorStatus.TERM_NOT_FOUND));
+            memberTermRepository.findByMemberAndTerm(findMember, term)
+                .ifPresentOrElse(
+                    mt -> mt.updateIsAgree(false),
+                    () -> {
+                        MemberTerm newMemberTerm = MemberConverter.toMemberTerm(findMember, term, false);
+                        memberTermRepository.save(newMemberTerm);
+                    }
+                );
+        }
+        // 응답 반환
+        return MemberConverter.toMemberSignupResponse(findMember);
+    }
+
+    // 추가 정보 필수 입력값 검증
+    private boolean validateAdditionalInfo(MemberRequestDTO.MemberSignupRequest request) {
+        return request.getNickname() != null &&
+               request.getUserCustomId() != null &&
+               request.getGender() != null &&
+               request.getBirth() != null;
+    }
+
+    // 필수 약관 동의 여부 검증
+    private boolean validateRequiredTerms(List<Long> agreeTermIdList) {
+        if (agreeTermIdList == null) return false;
+        List<Term> requiredTerms = termRepository.findByIsRequiredTrue();
+        for (Term term : requiredTerms) {
+            if (!agreeTermIdList.contains(term.getId())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/umc/plantory/domain/member/service/MemberCommandUseCase.java
+++ b/src/main/java/umc/plantory/domain/member/service/MemberCommandUseCase.java
@@ -1,0 +1,8 @@
+package umc.plantory.domain.member.service;
+
+import umc.plantory.domain.member.dto.MemberRequestDTO;
+import umc.plantory.domain.member.dto.MemberResponseDTO;
+
+public interface MemberCommandUseCase {
+    public MemberResponseDTO.MemberSignupResponse memberSignup(MemberRequestDTO.MemberSignupRequest request);
+}

--- a/src/main/java/umc/plantory/domain/term/repository/TermRepository.java
+++ b/src/main/java/umc/plantory/domain/term/repository/TermRepository.java
@@ -1,0 +1,10 @@
+package umc.plantory.domain.term.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.plantory.domain.term.entity.Term;
+
+import java.util.List;
+
+public interface TermRepository extends JpaRepository<Term, Long> {
+    List<Term> findByIsRequiredTrue();
+}

--- a/src/main/java/umc/plantory/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/plantory/global/apiPayload/code/status/ErrorStatus.java
@@ -15,6 +15,14 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
+    // 멤버 관련
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "존재하지 않는 회원입니다."),
+    INVALID_MEMBER_INFO(HttpStatus.BAD_REQUEST, "MEMBER4002", "회원 필수 정보가 누락되었습니다."),
+
+    // 약관 관련
+    TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "TERM4001", "존재하지 않는 약관입니다."),
+    REQUIRED_TERM_NOT_AGREED(HttpStatus.BAD_REQUEST, "TERM4002", "필수 약관에 동의하지 않았습니다."),
+
     ;
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/plantory/global/apiPayload/exception/handler/MemberHandler.java
+++ b/src/main/java/umc/plantory/global/apiPayload/exception/handler/MemberHandler.java
@@ -1,0 +1,10 @@
+package umc.plantory.global.apiPayload.exception.handler;
+
+import umc.plantory.global.apiPayload.code.BaseErrorCode;
+import umc.plantory.global.apiPayload.exception.GeneralException;
+
+public class MemberHandler extends GeneralException {
+    public MemberHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/umc/plantory/global/apiPayload/exception/handler/TermHandler.java
+++ b/src/main/java/umc/plantory/global/apiPayload/exception/handler/TermHandler.java
@@ -1,0 +1,11 @@
+package umc.plantory.global.apiPayload.exception.handler;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.plantory.global.apiPayload.code.BaseErrorCode;
+import umc.plantory.global.apiPayload.exception.GeneralException;
+
+public class TermHandler extends GeneralException {
+    public TermHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION


# 📌 Pull Request

## 📖 1. 변경 사항 요약
- 유저 회원가입 추가정보 입력 API 구조 및 방식 수정 구현

## 🔗 2. 관련 이슈
- #26 

## 🛠 3. 구현 내용 및 상세
PATCH /v1/plantory/member/signup
- 필수 약관 동의 여부, 정보 검증 및 저장
- 추가 정보(닉네임, 아이디, 성별, 생년월일, 약관 리스트) 전달
- 정보 저장 및 회원가입 완료
- 응답: 회원 아이디 반환

## 📋 4. 리뷰 요구사항
- 

## 💬 5. 참고 사항 
- 기존 회원가입 시 약관 동의, 추가정보 입력 API들을 하나로 구현했습니다.
