### PR TITLE
[#29] Kakao 소셜 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,18 @@ dependencies {
 	implementation platform("org.springframework.ai:spring-ai-bom:0.8.1")
 	implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter:0.8.1'
 
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// OAUTH2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+
+	// JWT
+	implementation 'com.auth0:java-jwt:4.4.0'
+
+	// RSA
+	implementation 'com.auth0:jwks-rsa:0.21.1'
+
 	// Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,10 +36,10 @@ dependencies {
 	implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter:0.8.1'
 
 	// Spring Security
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	//implementation 'org.springframework.boot:spring-boot-starter-security'
 
 	// OAUTH2
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+	//implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 
 	// JWT
 	implementation 'com.auth0:java-jwt:4.4.0'

--- a/src/main/java/umc/plantory/domain/kakao/converter/KakaoConverter.java
+++ b/src/main/java/umc/plantory/domain/kakao/converter/KakaoConverter.java
@@ -5,21 +5,22 @@ import umc.plantory.domain.member.dto.MemberDataDTO;
 import umc.plantory.domain.member.dto.MemberResponseDTO;
 import umc.plantory.global.enums.Gender;
 
+import java.time.LocalDateTime;
+
 public class KakaoConverter {
 
     public static MemberDataDTO.KakaoMemberData toKakaoMemberData(DecodedJWT verified) {
         return MemberDataDTO.KakaoMemberData.builder()
                 .sub(verified.getSubject())
-                .nickname(verified.getClaim("nickname").asString())
                 .email(verified.getClaim("email").asString())
-                .gender(verified.getClaim("gender").asString().equals("male") ? Gender.MALE : Gender.FEMALE )
                 .build();
     }
 
-    public static MemberResponseDTO.KkoOAuth2LoginResponse toKkoOAuth2LoginResponse(String accessToken, String refreshToken) {
+    public static MemberResponseDTO.KkoOAuth2LoginResponse toKkoOAuth2LoginResponse(String accessToken, String refreshToken, LocalDateTime accessTokenExpiredAt) {
         return MemberResponseDTO.KkoOAuth2LoginResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .accessTokenExpiredAt(accessTokenExpiredAt)
                 .build();
     }
 }

--- a/src/main/java/umc/plantory/domain/kakao/converter/KakaoConverter.java
+++ b/src/main/java/umc/plantory/domain/kakao/converter/KakaoConverter.java
@@ -1,0 +1,25 @@
+package umc.plantory.domain.kakao.converter;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import umc.plantory.domain.member.dto.MemberDataDTO;
+import umc.plantory.domain.member.dto.MemberResponseDTO;
+import umc.plantory.global.enums.Gender;
+
+public class KakaoConverter {
+
+    public static MemberDataDTO.KakaoMemberData toKakaoMemberData(DecodedJWT verified) {
+        return MemberDataDTO.KakaoMemberData.builder()
+                .sub(verified.getSubject())
+                .nickname(verified.getClaim("nickname").asString())
+                .email(verified.getClaim("email").asString())
+                .gender(verified.getClaim("gender").asString().equals("male") ? Gender.MALE : Gender.FEMALE )
+                .build();
+    }
+
+    public static MemberResponseDTO.KkoOAuth2LoginResponse toKkoOAuth2LoginResponse(String accessToken, String refreshToken) {
+        return MemberResponseDTO.KkoOAuth2LoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/umc/plantory/domain/kakao/service/KakaoOidcService.java
+++ b/src/main/java/umc/plantory/domain/kakao/service/KakaoOidcService.java
@@ -30,6 +30,9 @@ public class KakaoOidcService {
     // ISSER 상수 -> id_token 안에 들어 있는 iss claim과 비교해 정품 Kakao 토큰인지 검증
     private static final String ISSUER = "https://kauth.kakao.com";
 
+    /**
+     * id_token을 검증하고 담겨있는 멤버 데이터 추출하는 메서드
+     */
     public MemberDataDTO.KakaoMemberData verifyAndParseIdToken(MemberRequestDTO.KkoOAuth2LoginRequest request) {
         try {
             // id_token 디코딩 : 헤더와 payload 읽기 위해 필요

--- a/src/main/java/umc/plantory/domain/kakao/service/KakaoOidcService.java
+++ b/src/main/java/umc/plantory/domain/kakao/service/KakaoOidcService.java
@@ -1,0 +1,64 @@
+package umc.plantory.domain.kakao.service;
+
+import com.auth0.jwk.Jwk;
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.UrlJwkProvider;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.auth0.jwt.interfaces.JWTVerifier;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import umc.plantory.domain.kakao.converter.KakaoConverter;
+import umc.plantory.domain.member.dto.MemberDataDTO;
+import umc.plantory.domain.member.dto.MemberRequestDTO;
+import umc.plantory.global.apiPayload.code.status.ErrorStatus;
+import umc.plantory.global.apiPayload.exception.handler.KakaoHandler;
+
+import java.net.URL;
+import java.security.interfaces.RSAPublicKey;
+
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class KakaoOidcService {
+    // Kakao 공개키 -> Kakao 가 서명한 JWT(id_token) 을 검증하기 위해선 공개키(JWK) 필요
+    private static final String JWK_URL = "https://kauth.kakao.com/.well-known/jwks.json";
+    // ISSER 상수 -> id_token 안에 들어 있는 iss claim과 비교해 정품 Kakao 토큰인지 검증
+    private static final String ISSUER = "https://kauth.kakao.com";
+
+    public MemberDataDTO.KakaoMemberData verifyAndParseIdToken(MemberRequestDTO.KkoOAuth2LoginRequest request) {
+        try {
+            // id_token 디코딩 : 헤더와 payload 읽기 위해 필요
+            DecodedJWT decodedJWT = JWT.decode(request.getIdToken());
+
+            /*
+            Kakao 공개키 가져오기
+            decodedJWT.getKeyId() : JWT Header에 있는 kid 값
+            이 kid에 해당하는 공개키를 Kakao의 JWK 서버에서 찾아옴
+            반환된 Jwk 는 Kakao가 서명할 때 썼던 RSA 공개키를 포함
+            */
+            JwkProvider jwkProvider = new UrlJwkProvider(new URL((JWK_URL)));
+            Jwk jwk = jwkProvider.get(decodedJWT.getKeyId());
+
+            // 가져온 공개키로 RSA256 서명 검증용 알고리즘 생성 -> JWT는 서명 검증에만 공개키 사용 (비밀키 X -> null)
+            Algorithm algorithm = Algorithm.RSA256((RSAPublicKey) jwk.getPublicKey(), null);
+
+            // 알고리즘 + issuer 설정
+            JWTVerifier jwtVerifier = JWT.require(algorithm)
+                    .withIssuer(ISSUER)
+                    .build();
+
+            // 실제 JWT 검증 수행
+            DecodedJWT verified = jwtVerifier.verify(request.getIdToken());
+
+            return KakaoConverter.toKakaoMemberData(verified);
+        } catch (Exception e) {
+            log.error("KakaoOidcService Error Occurred: {}", e.getMessage());
+            throw new KakaoHandler(ErrorStatus.ERROR_ON_VERIFYING);
+        }
+    }
+}

--- a/src/main/java/umc/plantory/domain/member/controller/MemberRestController.java
+++ b/src/main/java/umc/plantory/domain/member/controller/MemberRestController.java
@@ -13,8 +13,8 @@ import umc.plantory.domain.member.dto.MemberDataDTO;
 import umc.plantory.domain.member.dto.MemberRequestDTO;
 import umc.plantory.domain.member.dto.MemberResponseDTO;
 import umc.plantory.domain.member.entity.Member;
-import umc.plantory.domain.member.service.MemberCommandService;
-import umc.plantory.domain.token.service.MemberTokenCommandService;
+import umc.plantory.domain.member.service.MemberCommandUseCase;
+import umc.plantory.domain.token.service.MemberTokenCommandUseCase;
 import umc.plantory.global.apiPayload.ApiResponse;
 
 @RestController
@@ -23,8 +23,8 @@ import umc.plantory.global.apiPayload.ApiResponse;
 @Tag(name = "Member", description = "회원 관련 API")
 public class MemberRestController {
     private final KakaoOidcService kakaoOidcService;
-    private final MemberCommandService memberService;
-    private final MemberTokenCommandService memberTokenService;
+    private final MemberCommandUseCase memberService;
+    private final MemberTokenCommandUseCase memberTokenService;
 
     @PostMapping("/kko/login")
     @Operation(summary = "KAKAO OAuth2 로그인 API", description = "KAKAO OAuth2 로그인 API 입니다.")

--- a/src/main/java/umc/plantory/domain/member/controller/MemberRestController.java
+++ b/src/main/java/umc/plantory/domain/member/controller/MemberRestController.java
@@ -1,0 +1,42 @@
+package umc.plantory.domain.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.plantory.domain.kakao.service.KakaoOidcService;
+import umc.plantory.domain.member.dto.MemberDataDTO;
+import umc.plantory.domain.member.dto.MemberRequestDTO;
+import umc.plantory.domain.member.dto.MemberResponseDTO;
+import umc.plantory.domain.member.entity.Member;
+import umc.plantory.domain.member.service.MemberCommandService;
+import umc.plantory.domain.token.service.MemberTokenCommandService;
+import umc.plantory.global.apiPayload.ApiResponse;
+
+@RestController
+@RequestMapping("/v1/plantory/member")
+@RequiredArgsConstructor
+@Tag(name = "Member", description = "회원 관련 API")
+public class MemberRestController {
+    private final KakaoOidcService kakaoOidcService;
+    private final MemberCommandService memberService;
+    private final MemberTokenCommandService memberTokenService;
+
+    @PostMapping("/kko/login")
+    @Operation(summary = "KAKAO OAuth2 로그인 API", description = "KAKAO OAuth2 로그인 API 입니다.")
+    public ResponseEntity<ApiResponse<MemberResponseDTO.KkoOAuth2LoginResponse>> kkoOAuth2Login
+            (@RequestBody MemberRequestDTO.KkoOAuth2LoginRequest request) {
+        // id_token 검증 후 멤버 데이터 추출
+        MemberDataDTO.KakaoMemberData kakaoMemberData = kakaoOidcService.verifyAndParseIdToken(request);
+
+        // id_token 에서 추출한 데이터를 통해 멤버 조회 OR 생성
+        Member findOrCreateMember = memberService.findOrCreateMember(kakaoMemberData);
+
+        // 토큰 생성 및 응답
+        return ResponseEntity.ok(ApiResponse.onSuccess(memberTokenService.generateToken(findOrCreateMember)));
+    }
+}

--- a/src/main/java/umc/plantory/domain/member/converter/MemberConverter.java
+++ b/src/main/java/umc/plantory/domain/member/converter/MemberConverter.java
@@ -1,0 +1,26 @@
+package umc.plantory.domain.member.converter;
+
+import umc.plantory.domain.member.dto.MemberDataDTO;
+import umc.plantory.domain.member.entity.Member;
+import umc.plantory.global.enums.MemberRole;
+import umc.plantory.global.enums.MemberStatus;
+import umc.plantory.global.enums.Provider;
+
+public class MemberConverter {
+    private static final String defaultProfileImg = "";
+
+    public static Member toMember (MemberDataDTO.KakaoMemberData kakaoMemberData) {
+        return Member.builder()
+                .nickname(kakaoMemberData.getNickname())
+                .email(kakaoMemberData.getEmail())
+                .userCustomId("")
+                .profileImgUrl(defaultProfileImg)
+                .provider(Provider.KAKAO)
+                .providerId(kakaoMemberData.getSub())
+                .gender(kakaoMemberData.getGender())
+                .status(MemberStatus.PENDING)
+                .role(MemberRole.USER)
+                .build();
+    }
+
+}

--- a/src/main/java/umc/plantory/domain/member/converter/MemberConverter.java
+++ b/src/main/java/umc/plantory/domain/member/converter/MemberConverter.java
@@ -10,12 +10,13 @@ import umc.plantory.global.enums.Provider;
 public class MemberConverter {
     private static final String DEFAULT_NICKNAME = "토리";
     private static final String DEFAULT_PROFILE_IMG = "https://plantory.s3.ap-northeast-2.amazonaws.com/profile/plantory_default_img.png";
+    private static final String DEFAULT_USER_CUSTOM_ID = "temp_plantory";
 
     public static Member toMember (MemberDataDTO.KakaoMemberData kakaoMemberData) {
         return Member.builder()
                 .nickname(DEFAULT_NICKNAME)
                 .email(kakaoMemberData.getEmail())
-                .userCustomId("")
+                .userCustomId(DEFAULT_USER_CUSTOM_ID)
                 .profileImgUrl(DEFAULT_PROFILE_IMG)
                 .provider(Provider.KAKAO)
                 .providerId(kakaoMemberData.getSub())

--- a/src/main/java/umc/plantory/domain/member/converter/MemberConverter.java
+++ b/src/main/java/umc/plantory/domain/member/converter/MemberConverter.java
@@ -8,15 +8,15 @@ import umc.plantory.global.enums.MemberStatus;
 import umc.plantory.global.enums.Provider;
 
 public class MemberConverter {
-    private static final String defaultNickname = "토리";
-    private static final String defaultProfileImg = "";
+    private static final String DEFAULT_NICKNAME = "토리";
+    private static final String DEFAULT_PROFILE_IMG = "https://plantory.s3.ap-northeast-2.amazonaws.com/profile/plantory_default_img.png";
 
     public static Member toMember (MemberDataDTO.KakaoMemberData kakaoMemberData) {
         return Member.builder()
-                .nickname(defaultNickname)
+                .nickname(DEFAULT_NICKNAME)
                 .email(kakaoMemberData.getEmail())
                 .userCustomId("")
-                .profileImgUrl(defaultProfileImg)
+                .profileImgUrl(DEFAULT_PROFILE_IMG)
                 .provider(Provider.KAKAO)
                 .providerId(kakaoMemberData.getSub())
                 .gender(Gender.NONE)

--- a/src/main/java/umc/plantory/domain/member/converter/MemberConverter.java
+++ b/src/main/java/umc/plantory/domain/member/converter/MemberConverter.java
@@ -2,22 +2,24 @@ package umc.plantory.domain.member.converter;
 
 import umc.plantory.domain.member.dto.MemberDataDTO;
 import umc.plantory.domain.member.entity.Member;
+import umc.plantory.global.enums.Gender;
 import umc.plantory.global.enums.MemberRole;
 import umc.plantory.global.enums.MemberStatus;
 import umc.plantory.global.enums.Provider;
 
 public class MemberConverter {
+    private static final String defaultNickname = "토리";
     private static final String defaultProfileImg = "";
 
     public static Member toMember (MemberDataDTO.KakaoMemberData kakaoMemberData) {
         return Member.builder()
-                .nickname(kakaoMemberData.getNickname())
+                .nickname(defaultNickname)
                 .email(kakaoMemberData.getEmail())
                 .userCustomId("")
                 .profileImgUrl(defaultProfileImg)
                 .provider(Provider.KAKAO)
                 .providerId(kakaoMemberData.getSub())
-                .gender(kakaoMemberData.getGender())
+                .gender(Gender.NONE)
                 .status(MemberStatus.PENDING)
                 .role(MemberRole.USER)
                 .build();

--- a/src/main/java/umc/plantory/domain/member/dto/MemberDataDTO.java
+++ b/src/main/java/umc/plantory/domain/member/dto/MemberDataDTO.java
@@ -1,0 +1,21 @@
+package umc.plantory.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.plantory.global.enums.Gender;
+
+public class MemberDataDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class KakaoMemberData {
+        private String nickname;
+        private String email;
+        private String sub; // provider_id
+        private Gender gender;
+    }
+}

--- a/src/main/java/umc/plantory/domain/member/dto/MemberDataDTO.java
+++ b/src/main/java/umc/plantory/domain/member/dto/MemberDataDTO.java
@@ -13,9 +13,7 @@ public class MemberDataDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class KakaoMemberData {
-        private String nickname;
         private String email;
         private String sub; // provider_id
-        private Gender gender;
     }
 }

--- a/src/main/java/umc/plantory/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/umc/plantory/domain/member/dto/MemberRequestDTO.java
@@ -1,0 +1,17 @@
+package umc.plantory.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MemberRequestDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class KkoOAuth2LoginRequest {
+        private String idToken;
+    }
+}

--- a/src/main/java/umc/plantory/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/plantory/domain/member/dto/MemberResponseDTO.java
@@ -1,0 +1,18 @@
+package umc.plantory.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MemberResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class KkoOAuth2LoginResponse {
+        private String accessToken;
+        private String refreshToken;
+    }
+}

--- a/src/main/java/umc/plantory/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/plantory/domain/member/dto/MemberResponseDTO.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 public class MemberResponseDTO {
 
     @Builder
@@ -14,5 +16,6 @@ public class MemberResponseDTO {
     public static class KkoOAuth2LoginResponse {
         private String accessToken;
         private String refreshToken;
+        private LocalDateTime accessTokenExpiredAt;
     }
 }

--- a/src/main/java/umc/plantory/domain/member/entity/Member.java
+++ b/src/main/java/umc/plantory/domain/member/entity/Member.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import umc.plantory.global.baseEntity.BaseEntity;
+import umc.plantory.global.enums.Gender;
 import umc.plantory.global.enums.MemberRole;
 import umc.plantory.global.enums.MemberStatus;
 import umc.plantory.global.enums.Provider;
@@ -26,17 +27,17 @@ public class Member extends BaseEntity {
     @Column(name = "member_id")
     private Long id;
 
-    @Column(length = 10, nullable = false)
-    private String name;
-
     @Column(length = 25, nullable = false, unique = true)
     private String nickname;
 
     @Column(length = 100, nullable = false)
     private String email;
 
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
     @Column(length = 25, nullable = false, unique = true)
-    private String userId;
+    private String userCustomId;
 
     @Column(length = 255, nullable = false)
     private String profileImgUrl;

--- a/src/main/java/umc/plantory/domain/member/repository/MemberRepository.java
+++ b/src/main/java/umc/plantory/domain/member/repository/MemberRepository.java
@@ -3,5 +3,8 @@ package umc.plantory.domain.member.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.plantory.domain.member.entity.Member;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByProviderId(String sub);
 }

--- a/src/main/java/umc/plantory/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/plantory/domain/member/service/MemberCommandService.java
@@ -1,0 +1,31 @@
+package umc.plantory.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.plantory.domain.member.converter.MemberConverter;
+import umc.plantory.domain.member.dto.MemberDataDTO;
+import umc.plantory.domain.member.entity.Member;
+import umc.plantory.domain.member.repository.MemberRepository;
+
+@Service
+@RequiredArgsConstructor
+public class MemberCommandService implements MemberCommandUseCase {
+    private final MemberRepository memberRepository;
+
+    /**
+     * id_token 에서 추출한 멤버 데이터를 통해
+     * 기존 회원이라면 조회해서 가져오고
+     * 첫 로그인이면 데이터 저장하는 메서드
+     * @param kakaoMemberData : id_token 에서 추출한 멤버 데이터
+     * @return : 추출한 멤버 데이터와 일치하는 멤버
+     */
+    @Override
+    @Transactional
+    public Member findOrCreateMember(MemberDataDTO.KakaoMemberData kakaoMemberData) {
+        Member findOrNewMember = memberRepository.findByProviderId(kakaoMemberData.getSub())
+                .orElseGet(() -> MemberConverter.toMember(kakaoMemberData));
+
+        return memberRepository.save(findOrNewMember);
+    }
+}

--- a/src/main/java/umc/plantory/domain/member/service/MemberCommandUseCase.java
+++ b/src/main/java/umc/plantory/domain/member/service/MemberCommandUseCase.java
@@ -1,0 +1,8 @@
+package umc.plantory.domain.member.service;
+
+import umc.plantory.domain.member.dto.MemberDataDTO;
+import umc.plantory.domain.member.entity.Member;
+
+public interface MemberCommandUseCase {
+    Member findOrCreateMember(MemberDataDTO.KakaoMemberData kakaoMemberData);
+}

--- a/src/main/java/umc/plantory/domain/token/converter/MemberTokenConverter.java
+++ b/src/main/java/umc/plantory/domain/token/converter/MemberTokenConverter.java
@@ -1,0 +1,17 @@
+package umc.plantory.domain.token.converter;
+
+import umc.plantory.domain.member.entity.Member;
+import umc.plantory.domain.token.entity.MemberToken;
+
+import java.time.LocalDateTime;
+
+public class MemberTokenConverter {
+
+    public static MemberToken toMemberToken(Member member, String refreshToken, LocalDateTime expiredAt) {
+        return MemberToken.builder()
+                .member(member)
+                .refreshToken(refreshToken)
+                .expiredAt(expiredAt)
+                .build();
+    }
+}

--- a/src/main/java/umc/plantory/domain/token/entity/MemberToken.java
+++ b/src/main/java/umc/plantory/domain/token/entity/MemberToken.java
@@ -26,7 +26,7 @@ public class MemberToken extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @Column(length = 100, nullable = false, updatable = false)
+    @Column(length = 500, nullable = false, updatable = false)
     private String refreshToken;
 
     @Column(nullable = false)

--- a/src/main/java/umc/plantory/domain/token/provider/JwtProvider.java
+++ b/src/main/java/umc/plantory/domain/token/provider/JwtProvider.java
@@ -1,0 +1,102 @@
+package umc.plantory.domain.token.provider;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import umc.plantory.domain.member.entity.Member;
+import umc.plantory.domain.member.repository.MemberRepository;
+import umc.plantory.global.apiPayload.code.status.ErrorStatus;
+import umc.plantory.global.apiPayload.exception.handler.JwtHandler;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+    @Value("${jwt.secret}")
+    private String secret;
+    @Value("${jwt.access-token-expiration}")
+    private Long ACCESS_TOKEN_EXPIRATION;
+    @Value("${jwt.refresh-token-expiration}")
+    private Long REFRESH_TOKEN_EXPIRATION;
+
+    private final MemberRepository memberRepository;
+
+    /**
+     * Access Token 생성 메서드
+     */
+    public String generateAccessToken(Member member) {
+        return JWT.create()
+                .withSubject(member.getId().toString())
+                .withExpiresAt(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRATION))
+                .sign(Algorithm.HMAC256(secret)); // 비대칭이 아닌 대칭키 사용
+    }
+
+    /**
+     * Refresh Token 생성
+     */
+    public String generateRefreshToken(Member member) {
+        return JWT.create()
+                .withSubject(member.getId().toString())
+                .withExpiresAt(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRATION))
+                .sign(Algorithm.HMAC256(secret));
+    }
+
+    /**
+     * JWT 유효성 검증 (true/false)
+     */
+    public boolean validateToken(String token) {
+        try {
+            JWT.require(Algorithm.HMAC256(secret)).build().verify(token);
+            return true;
+        } catch (TokenExpiredException e) {
+            throw new JwtHandler(ErrorStatus.EXPIRED_JWT_TOKEN);
+        } catch (Exception e) {
+            throw new JwtHandler(ErrorStatus.INVALID_JWT_TOKEN);
+        }
+    }
+
+    /**
+     * JWT에서 사용자 ID 추출
+     */
+    public Long getMemberId(String token) {
+        try {
+            JWTVerifier verifier = JWT.require(Algorithm.HMAC256(secret)).build();
+            DecodedJWT decodedJWT = verifier.verify(token);
+            return Long.valueOf(decodedJWT.getSubject());
+        } catch (Exception e) {
+            throw new JwtHandler(ErrorStatus.INVALID_JWT_TOKEN);
+        }
+    }
+
+    /**
+     * Authorization 헤더에서 실제 토큰 추출
+     */
+    public String resolveToken(String bearerHeader) {
+        if (bearerHeader != null && bearerHeader.startsWith("Bearer ")) {
+            return bearerHeader.substring(7);
+        }
+        return null;
+    }
+
+    /**
+     * 만료 시간 추출
+     */
+    public LocalDateTime getExpiredAt(String token) {
+        try {
+            DecodedJWT decodedJWT = JWT.require(Algorithm.HMAC256(secret))
+                    .build()
+                    .verify(token);
+            return LocalDateTime.ofInstant(decodedJWT.getExpiresAt().toInstant(), ZoneId.systemDefault());
+        } catch (Exception e) {
+            throw new JwtHandler(ErrorStatus.INVALID_JWT_TOKEN);
+        }
+    }
+}

--- a/src/main/java/umc/plantory/domain/token/repository/MemberTokenRepository.java
+++ b/src/main/java/umc/plantory/domain/token/repository/MemberTokenRepository.java
@@ -1,0 +1,7 @@
+package umc.plantory.domain.token.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.plantory.domain.token.entity.MemberToken;
+
+public interface MemberTokenRepository extends JpaRepository<MemberToken, Long>{
+}

--- a/src/main/java/umc/plantory/domain/token/service/MemberTokenCommandService.java
+++ b/src/main/java/umc/plantory/domain/token/service/MemberTokenCommandService.java
@@ -10,23 +10,32 @@ import umc.plantory.domain.token.converter.MemberTokenConverter;
 import umc.plantory.domain.token.provider.JwtProvider;
 import umc.plantory.domain.token.repository.MemberTokenRepository;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class MemberTokenCommandService implements MemberTokenCommandUseCase {
     private final MemberTokenRepository memberTokenRepository;
     private final JwtProvider jwtProvider;
 
+    /**
+     * 유저 데이터를 통해 Access/Refresh 토큰 생성하는 메서드
+     */
     @Override
     @Transactional
     public MemberResponseDTO.KkoOAuth2LoginResponse generateToken(Member member) {
         // Access Token 생성
         String accessToken = jwtProvider.generateAccessToken(member);
-
         // Refresh Token 생성
         String refreshToken = jwtProvider.generateRefreshToken(member);
+        // Access Token 만료시간
+        LocalDateTime accessTokenExpiredAt = jwtProvider.getExpiredAt(accessToken);
+        // Refresh Token 만료 시간
+        LocalDateTime refreshTokenExpiredAt = jwtProvider.getExpiredAt(refreshToken);
 
         // MemberToken 에 저장
-        memberTokenRepository.save(MemberTokenConverter.toMemberToken(member, refreshToken, jwtProvider.getExpiredAt(refreshToken)));
-        return KakaoConverter.toKkoOAuth2LoginResponse(accessToken, refreshToken);
+        memberTokenRepository.save(MemberTokenConverter.toMemberToken(member, refreshToken, refreshTokenExpiredAt));
+
+        return KakaoConverter.toKkoOAuth2LoginResponse(accessToken, refreshToken, accessTokenExpiredAt);
     }
 }

--- a/src/main/java/umc/plantory/domain/token/service/MemberTokenCommandService.java
+++ b/src/main/java/umc/plantory/domain/token/service/MemberTokenCommandService.java
@@ -1,0 +1,32 @@
+package umc.plantory.domain.token.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.plantory.domain.kakao.converter.KakaoConverter;
+import umc.plantory.domain.member.dto.MemberResponseDTO;
+import umc.plantory.domain.member.entity.Member;
+import umc.plantory.domain.token.converter.MemberTokenConverter;
+import umc.plantory.domain.token.provider.JwtProvider;
+import umc.plantory.domain.token.repository.MemberTokenRepository;
+
+@Service
+@RequiredArgsConstructor
+public class MemberTokenCommandService implements MemberTokenCommandUseCase {
+    private final MemberTokenRepository memberTokenRepository;
+    private final JwtProvider jwtProvider;
+
+    @Override
+    @Transactional
+    public MemberResponseDTO.KkoOAuth2LoginResponse generateToken(Member member) {
+        // Access Token 생성
+        String accessToken = jwtProvider.generateAccessToken(member);
+
+        // Refresh Token 생성
+        String refreshToken = jwtProvider.generateRefreshToken(member);
+
+        // MemberToken 에 저장
+        memberTokenRepository.save(MemberTokenConverter.toMemberToken(member, refreshToken, jwtProvider.getExpiredAt(refreshToken)));
+        return KakaoConverter.toKkoOAuth2LoginResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/umc/plantory/domain/token/service/MemberTokenCommandUseCase.java
+++ b/src/main/java/umc/plantory/domain/token/service/MemberTokenCommandUseCase.java
@@ -1,0 +1,8 @@
+package umc.plantory.domain.token.service;
+
+import umc.plantory.domain.member.dto.MemberResponseDTO;
+import umc.plantory.domain.member.entity.Member;
+
+public interface MemberTokenCommandUseCase {
+    MemberResponseDTO.KkoOAuth2LoginResponse generateToken(Member member);
+}

--- a/src/main/java/umc/plantory/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/plantory/global/apiPayload/code/status/ErrorStatus.java
@@ -18,6 +18,14 @@ public enum ErrorStatus implements BaseErrorCode {
     // 멤버 관련
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "존재하지 않는 회원입니다."),
 
+    // KAKAO 관련
+    INVALID_ID_TOKEN(HttpStatus.BAD_REQUEST, "KAKAO4001", "유효하지 않은 ID Token 입니다."),
+    ERROR_ON_VERIFYING(HttpStatus.INTERNAL_SERVER_ERROR, "KAKAO4002", "카카오 토큰 검증 도중 에러 발생"),
+
+    // JWT 관련
+    INVALID_JWT_TOKEN(HttpStatus.BAD_REQUEST, "JWT4001", "유효하지 않은 JWT 토큰입니다."),
+    EXPIRED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "JWT4002", "만료된 JWT 토큰입니다."),
+
     // S3 관련
     INVALID_EXTENSION(HttpStatus.BAD_REQUEST, "S34001", "허용되지 않은 파일 확장자입니다."),
     INVALID_FILENAME(HttpStatus.BAD_REQUEST, "S34002", "파일 이름이 유효하지 않습니다."),

--- a/src/main/java/umc/plantory/global/apiPayload/exception/handler/JwtHandler.java
+++ b/src/main/java/umc/plantory/global/apiPayload/exception/handler/JwtHandler.java
@@ -1,0 +1,10 @@
+package umc.plantory.global.apiPayload.exception.handler;
+
+import umc.plantory.global.apiPayload.code.BaseErrorCode;
+import umc.plantory.global.apiPayload.exception.GeneralException;
+
+public class JwtHandler extends GeneralException {
+    public JwtHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/umc/plantory/global/apiPayload/exception/handler/KakaoHandler.java
+++ b/src/main/java/umc/plantory/global/apiPayload/exception/handler/KakaoHandler.java
@@ -1,0 +1,10 @@
+package umc.plantory.global.apiPayload.exception.handler;
+
+import umc.plantory.global.apiPayload.code.BaseErrorCode;
+import umc.plantory.global.apiPayload.exception.GeneralException;
+
+public class KakaoHandler extends GeneralException {
+    public KakaoHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/umc/plantory/global/config/SwaggerConfig.java
+++ b/src/main/java/umc/plantory/global/config/SwaggerConfig.java
@@ -37,12 +37,12 @@ public class SwaggerConfig {
                 .components(components);
     }
 
-    @Bean
+    /*@Bean
     public GroupedOpenApi chatbotOpenApi() {
         return GroupedOpenApi.builder()
                 .group("챗봇 API")
                 .displayName("챗봇 API")
                 .pathsToMatch("/v1/plantory/chat/**")
                 .build();
-    }
+    }*/
 }

--- a/src/main/java/umc/plantory/global/enums/Gender.java
+++ b/src/main/java/umc/plantory/global/enums/Gender.java
@@ -1,5 +1,5 @@
 package umc.plantory.global.enums;
 
 public enum Gender {
-    MALE, FEMALE
+    MALE, FEMALE, NONE
 }


### PR DESCRIPTION
<!-- 이부분은 확인 후 지워주세요!
PR 제목은 "[#이슈번호] 간결하고 핵심적인 내용"
    ex) [#123] 로그인 기능 구현
PR 올리기 전 확인사항
- application.yml 업데이트 했을 경우 팀에 공유 및 노션 수정은 했나요?
- 리뷰어 설정은 했나요?
- Assignees 설정은 했나요?
- Label 설정은 알맞게 했나요?
- 이슈 연결은 알맞게 했나요?
- base 브랜치는 확인했나요?
-->

# 📌 Pull Request

## 📖 1. 변경 사항 요약
- Member Entity 수정
  - name 필드 삭제
  -  Gender 필드 추가
  - userId -> userCustomId 필드명 변경
- MemberToken Entity 수정
  - refreshToken 길이 변경 100 -> 500

## 🔗 2. 관련 이슈
- #29 

## 🛠 3. 구현 내용 및 상세
- Front 요청사항에 맞게 id_token 값 받아서 소셜 로그인 진행
- id_token 검증 후 멤버 데이터 추출
- 첫 로그인이면 Member 테이블에 데이터 저장
- 추출한 데이터를 통해 access/refresh Token 발급
  - accessToken 유효 기간 : 1시간
  - refreshToken 유효 기간 : 14일

- 헤더로 들어오는 Bearer 토큰은 JwtProvider 에 resolveToken() 메서드를 통해 Bearer 부분을 제거한 뒤 getMemberId() 메서드를 사용하면 토큰에서 memberId 추출 가능합니다.

## 📋 4. 리뷰 요구사항
- 

## 💬 5. 참고 사항 
- 아직 Spring Security 적용 전입니다. 급한 부분은 아니라서 데모데이 후에 진행될 수 있습니다.
