### PR TITLE
[#43] RequestHeader 에 required = false 추가

### DIFF
--- a/src/main/java/umc/plantory/domain/diary/controller/DiaryRestController.java
+++ b/src/main/java/umc/plantory/domain/diary/controller/DiaryRestController.java
@@ -33,7 +33,7 @@ public class DiaryRestController {
     })
     @PostMapping
     public ResponseEntity<ApiResponse<DiaryResponseDTO.DiaryInfoDTO>> saveDiary(
-            @RequestHeader("Authorization") String authorization,
+            @RequestHeader(value = "Authorization", required = false) String authorization,
             @Valid @RequestBody DiaryRequestDTO.DiaryUploadDTO requestDTO
     ) {
         return ResponseEntity.ok(ApiResponse.onSuccess(diaryCommandUseCase.saveDiary(authorization, requestDTO)));
@@ -52,7 +52,7 @@ public class DiaryRestController {
     })
     @PatchMapping("/{diaryId}")
     public ResponseEntity<ApiResponse<DiaryResponseDTO.DiaryInfoDTO>> updateDiary(
-            @RequestHeader("Authorization") String authorization,
+            @RequestHeader(value = "Authorization", required = false) String authorization,
             @Parameter(description = "수정할 일기의 ID", required = true)
             @PathVariable("diaryId") Long diaryId,
             @Valid @RequestBody DiaryRequestDTO.DiaryUpdateDTO requestDTO
@@ -72,7 +72,7 @@ public class DiaryRestController {
     })
     @PatchMapping("/{diaryId}/scrap/on")
     public ResponseEntity<ApiResponse<Void>> scrapDiary(
-            @RequestHeader("Authorization") String authorization,
+            @RequestHeader(value = "Authorization", required = false) String authorization,
             @Parameter(description = "스크랩할 일기의 ID") @PathVariable Long diaryId
     ) {
         diaryCommandUseCase.scrapDiary(authorization, diaryId);
@@ -91,7 +91,7 @@ public class DiaryRestController {
     })
     @PatchMapping("/{diaryId}/scrap/off")
     public ResponseEntity<ApiResponse<Void>> cancelScrapDiary(
-            @RequestHeader("Authorization") String authorization,
+            @RequestHeader(value = "Authorization", required = false) String authorization,
             @Parameter(description = "스크랩 취소할 일기의 ID") @PathVariable Long diaryId
     ) {
         diaryCommandUseCase.cancelScrapDiary(authorization, diaryId);
@@ -109,7 +109,7 @@ public class DiaryRestController {
     })
     @PatchMapping("/temp")
     public ResponseEntity<ApiResponse<Void>> tempSaveDiaries(
-            @RequestHeader("Authorization") String authorization,
+            @RequestHeader(value = "Authorization", required = false) String authorization,
             @Valid @RequestBody DiaryRequestDTO.DiaryIdsDTO requestDTO
     ) {
         diaryCommandUseCase.tempSaveDiaries(authorization, requestDTO);
@@ -127,7 +127,7 @@ public class DiaryRestController {
     })
     @PatchMapping("/waste")
     public ResponseEntity<ApiResponse<Void>> moveDiariesToTrash(
-            @RequestHeader("Authorization") String authorization,
+            @RequestHeader(value = "Authorization", required = false) String authorization,
             @Valid @RequestBody DiaryRequestDTO.DiaryIdsDTO request
     ) {
         diaryCommandUseCase.softDeleteDiaries(authorization, request);
@@ -145,7 +145,7 @@ public class DiaryRestController {
     })
     @DeleteMapping
     public ResponseEntity<ApiResponse<Void>> hardDeleteDiaries(
-            @RequestHeader("Authorization") String authorization,
+            @RequestHeader(value = "Authorization", required = false) String authorization,
             @Valid @RequestBody DiaryRequestDTO.DiaryIdsDTO request
     ) {
         diaryCommandUseCase.hardDeleteDiaries(authorization, request);

--- a/src/main/java/umc/plantory/domain/member/controller/MemberRestController.java
+++ b/src/main/java/umc/plantory/domain/member/controller/MemberRestController.java
@@ -28,7 +28,7 @@ public class MemberRestController {
     @GetMapping("/profile")
     @Operation(summary = "마이페이지 프로필 조회 API", description = "회원의 프로필 정보와 통계를 조회하는 API입니다.")
     public ResponseEntity<ApiResponse<MemberResponseDTO.ProfileResponse>> getProfile(
-            @RequestHeader("Authorization") String authorization) {
+            @RequestHeader(value = "Authorization", required = false) String authorization) {
         return ResponseEntity.ok(ApiResponse.onSuccess(memberQueryUseCase.getProfile(authorization)));
     }
 


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약
- 기존 RequestHeader 에 required = false 추가

## 🔗 2. 관련 이슈
- Closes #43 

## 🛠 3. 구현 내용 및 상세
- required = false 추가

## 📋 4. 리뷰 요구사항
- 

## 💬 5. 참고 사항 
- 기존 코드일 땐 스웨거에서 아래 사진처럼 나옵니다.
<img width="586" height="133" alt="image" src="https://github.com/user-attachments/assets/3f5e9c63-8abe-4633-9824-bfdfd57171f8" />

- 변경 후엔
<img width="475" height="81" alt="image" src="https://github.com/user-attachments/assets/b4439ba6-0b23-4343-9389-53f6c25391b7" />

- 해당 parameter 에 액세스 코드를 계속 넣고 테스트하는 것이 아니라 아래 사진에 나오는 Authorize 버튼을 누르고 액세스 토큰을 넣고 로그인 하여 요청을 하면 자동으로 헤더가 넘어갑니다.
- 액세스 토큰을 채우고 로그인을 하면 자물쇠가 잠겨져 있습니다.
<img width="171" height="58" alt="image" src="https://github.com/user-attachments/assets/aeba8d8a-760e-4ff4-ab25-117cb232e619" />
<img width="683" height="318" alt="image" src="https://github.com/user-attachments/assets/ccce94dd-d5bb-4b8c-9ed3-c292ca1b0eef" />
<img width="140" height="374" alt="image" src="https://github.com/user-attachments/assets/59e31488-53db-41e7-9413-2a4d63f32345" />
