### PR TITLE
[#42] MemberToken Duplicate 버그 수정

### DIFF
--- a/src/main/java/umc/plantory/domain/token/entity/MemberToken.java
+++ b/src/main/java/umc/plantory/domain/token/entity/MemberToken.java
@@ -31,4 +31,9 @@ public class MemberToken extends BaseEntity {
 
     @Column(nullable = false)
     private LocalDateTime expiredAt;
+
+    public void updateRefreshTokenAndExpiredAt (String refreshToken, LocalDateTime expiredAt) {
+        this.refreshToken = refreshToken;
+        this.expiredAt = expiredAt;
+    }
 }

--- a/src/main/java/umc/plantory/domain/token/repository/MemberTokenRepository.java
+++ b/src/main/java/umc/plantory/domain/token/repository/MemberTokenRepository.java
@@ -1,7 +1,11 @@
 package umc.plantory.domain.token.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import umc.plantory.domain.member.entity.Member;
 import umc.plantory.domain.token.entity.MemberToken;
 
+import java.util.Optional;
+
 public interface MemberTokenRepository extends JpaRepository<MemberToken, Long>{
+    Optional<MemberToken> findByMember(Member member);
 }

--- a/src/main/java/umc/plantory/domain/token/service/MemberTokenCommandService.java
+++ b/src/main/java/umc/plantory/domain/token/service/MemberTokenCommandService.java
@@ -7,6 +7,7 @@ import umc.plantory.domain.kakao.converter.KakaoConverter;
 import umc.plantory.domain.member.dto.MemberResponseDTO;
 import umc.plantory.domain.member.entity.Member;
 import umc.plantory.domain.token.converter.MemberTokenConverter;
+import umc.plantory.domain.token.entity.MemberToken;
 import umc.plantory.domain.token.provider.JwtProvider;
 import umc.plantory.domain.token.repository.MemberTokenRepository;
 
@@ -24,6 +25,9 @@ public class MemberTokenCommandService implements MemberTokenCommandUseCase {
     @Override
     @Transactional
     public MemberResponseDTO.KkoOAuth2LoginResponse generateToken(Member member) {
+        MemberToken findMemberToken = memberTokenRepository.findByMember(member)
+                .orElse(null);
+
         // Access Token 생성
         String accessToken = jwtProvider.generateAccessToken(member);
         // Refresh Token 생성
@@ -33,8 +37,15 @@ public class MemberTokenCommandService implements MemberTokenCommandUseCase {
         // Refresh Token 만료 시간
         LocalDateTime refreshTokenExpiredAt = jwtProvider.getExpiredAt(refreshToken);
 
-        // MemberToken 에 저장
-        memberTokenRepository.save(MemberTokenConverter.toMemberToken(member, refreshToken, refreshTokenExpiredAt));
+        // 이미 MemberToken 이 있다면 UPDATE, 없다면 INSERT
+        if (findMemberToken == null) {
+            // MemberToken 에 저장
+            memberTokenRepository.save(MemberTokenConverter.toMemberToken(member, refreshToken, refreshTokenExpiredAt));
+        } else {
+            // MemberToken Update
+            findMemberToken.updateRefreshTokenAndExpiredAt(refreshToken, refreshTokenExpiredAt);
+            memberTokenRepository.save(findMemberToken);
+        }
 
         return KakaoConverter.toKkoOAuth2LoginResponse(accessToken, refreshToken, accessTokenExpiredAt);
     }


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약
- 로그인 후 토큰 생성 시 MemberToken 테이블에 이미 데이터가 있다면 INSERT 가 아닌 UPDATE 처리

## 🔗 2. 관련 이슈
- Closes #42 

## 🛠 3. 구현 내용 및 상세
- 로그인 후 토큰 생성 시 MemberToken 테이블에 이미 데이터가 있다면 INSERT 가 아닌 UPDATE 처리

## 📋 4. 리뷰 요구사항
- 

## 💬 5. 참고 사항 
- 
