### PR TITLE
[Feat] 일기 수정 시 제목 자동 생성 처리

### DIFF
--- a/src/main/java/umc/plantory/domain/diary/entity/Diary.java
+++ b/src/main/java/umc/plantory/domain/diary/entity/Diary.java
@@ -59,12 +59,14 @@ public class Diary extends BaseEntity {
     private DiaryStatus status;
 
     public void update(Emotion emotion,
+                       String title,
                        String content,
                        LocalDateTime sleepStartTime,
                        LocalDateTime sleepEndTime,
                        DiaryStatus status) {
 
         this.emotion = emotion;
+        this.title = title;
         this.content = content;
         this.sleepStartTime = sleepStartTime;
         this.sleepEndTime = sleepEndTime;

--- a/src/main/java/umc/plantory/domain/diary/service/DiaryCommandService.java
+++ b/src/main/java/umc/plantory/domain/diary/service/DiaryCommandService.java
@@ -58,10 +58,10 @@ public class DiaryCommandService implements DiaryCommandUseCase {
 
         // AI 프롬프트 생성 및 제목 응답 받기
         Prompt prompt = PromptFactory.buildDiaryTitlePrompt(request.getContent());
-        String diaryTitle = aiClient.getResponse(prompt);
+        String generatedTitle = aiClient.getResponse(prompt);
 
         // diary 엔티티 생성 및 저장
-        Diary diary = DiaryConverter.toDiary(request,member, diaryTitle);
+        Diary diary = DiaryConverter.toDiary(request,member, generatedTitle);
         diaryRepository.save(diary);
 
         // 이미지 등록 처리
@@ -105,7 +105,11 @@ public class DiaryCommandService implements DiaryCommandUseCase {
             throw new DiaryHandler(ErrorStatus.DIARY_MISSING_FIELDS);
         }
 
-        diary.update(emotion, content, sleepStart, sleepEnd, status);
+        // AI 프롬프트 생성 및 제목 응답 받기
+        Prompt prompt = PromptFactory.buildDiaryTitlePrompt(content);
+        String generatedTitle = aiClient.getResponse(prompt);
+
+        diary.update(emotion, generatedTitle, content, sleepStart, sleepEnd, status);
 
         handleWateringCan(diary, member);
         return DiaryConverter.toDiaryInfoDTO(diary, diaryImgUrl);


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약
일기가 수정 된 경우에도, 일기 내용을 기반으로 제목을 다시 생성하여 수정하도록 기능 추가했습니다.

## 🔗 2. 관련 이슈
  Closes #83

## 🛠 3. 구현 내용 및 상세
- DiaryCommandService.updateDiary() 내부에서 프롬프트 생성 및 AI 호출을 통해 generatedTitle 생성
- 일기 내용 수정 시, AI 기반으로 생성된 제목을 함께 반영할 수 있도록, Diary 엔티티의 update 메서드에 title 파라미터 추가

## 📋 4. 리뷰 요구사항
.

## 💬 5. 참고 사항 
- 추가로 알려야 할 사항이나 리뷰어에게 질문할 것이 있으면 작성해주세요.
