### PR TITLE
[#78] 물 주기 이벤트 API 로직 수정

### DIFF
--- a/src/main/java/umc/plantory/domain/terrarium/controller/TerrariumRestController.java
+++ b/src/main/java/umc/plantory/domain/terrarium/controller/TerrariumRestController.java
@@ -33,10 +33,10 @@ public class TerrariumRestController {
     @Operation(summary = "테라리움 물주기", description = "회원이 특정 테라리움에 물을 주는 요청 처리")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "물주기 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 - 예: 아직 개화하지 않은 테라리움, 이미 진행 중인 테라리움 존재", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "멤버, 테라리움, 꽃 정보 없음", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러 (WATERING_PROCESS_FAILED 등)", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4001", description = "존재하지 않는 회원입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TERRARIUM404", description = "존재하지 않는 테라리움입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TERRARIUM4004", description = "이미 개화한 테라리움입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "W4002", description = "사용 가능한 물뿌리개가 없습니다."),
     })
     @PostMapping("/{terrarium-id}/water")
     public ResponseEntity<ApiResponse<TerrariumResponseDto.WateringTerrariumResponse>> waterTerrarium(

--- a/src/main/java/umc/plantory/domain/terrarium/converter/TerrariumConverter.java
+++ b/src/main/java/umc/plantory/domain/terrarium/converter/TerrariumConverter.java
@@ -5,10 +5,12 @@ import umc.plantory.domain.member.entity.Member;
 import umc.plantory.domain.terrarium.dto.TerrariumResponseDto;
 import umc.plantory.domain.terrarium.dto.TerrariumResponseDto.TerrariumResponse;
 import umc.plantory.domain.terrarium.entity.Terrarium;
+import umc.plantory.global.enums.Emotion;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 public class TerrariumConverter {
 
@@ -35,15 +37,23 @@ public class TerrariumConverter {
 
     }
 
-    public static TerrariumResponseDto.WateringTerrariumResponse toWateringTerrariumResponse(int terrariumWateringCount,
-                                                                                             int memberWateringCount,
-                                                                                             List<Object[]> emotionCounts,
-                                                                                             Flower flower) {
+    public static TerrariumResponseDto.WateringTerrariumResponse toDefaultWateringTerrariumResponse(Integer terrariumWateringCountAfterEvent, Integer memberWateringCountAfterEvent) {
         return TerrariumResponseDto.WateringTerrariumResponse.builder()
-                .terrariumWateringCount(terrariumWateringCount)
-                .memberWateringCount(memberWateringCount)
-                .emotionCounts(emotionCounts)
+                .terrariumWateringCountAfterEvent(terrariumWateringCountAfterEvent)
+                .memberWateringCountAfterEvent(memberWateringCountAfterEvent)
+                .build();
+    }
+
+    public static TerrariumResponseDto.WateringTerrariumResponse toBloomWateringTerrariumResponse(Integer terrariumWateringCountAfterEvent,
+                                                                                                  Integer memberWateringCountAfterEvent,
+                                                                                                  Map<Emotion, Integer> emotionList,
+                                                                                                  Flower flower) {
+        return TerrariumResponseDto.WateringTerrariumResponse.builder()
+                .terrariumWateringCountAfterEvent(terrariumWateringCountAfterEvent)
+                .memberWateringCountAfterEvent(memberWateringCountAfterEvent)
+                .emotionList(emotionList)
                 .flowerName(flower.getName())
+                .flowerImgUrl(flower.getFlowerImgUrl())
                 .flowerEmotion(flower.getEmotion())
                 .build();
     }

--- a/src/main/java/umc/plantory/domain/terrarium/dto/TerrariumResponseDto.java
+++ b/src/main/java/umc/plantory/domain/terrarium/dto/TerrariumResponseDto.java
@@ -1,13 +1,16 @@
 package umc.plantory.domain.terrarium.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import umc.plantory.global.enums.Emotion;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 public class TerrariumResponseDto {
 
@@ -24,11 +27,14 @@ public class TerrariumResponseDto {
     @Builder
     @Getter
     @AllArgsConstructor
+    @NoArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_EMPTY) // 동적 응답을 위해 추가
     public static class WateringTerrariumResponse{
-        private Integer terrariumWateringCount; // WateringEvent 엔티티 내 terrarium_id로 조회한 물 뿌리개 갯수
-        private Integer memberWateringCount; // member 엔티티 내 watering_can_cnt 필드
-        private List<Object[]> emotionCounts; // 물뿌리기 7회 이상 시에 emotionCountsList
+        private Integer terrariumWateringCountAfterEvent;
+        private Integer memberWateringCountAfterEvent;
+        private Map<Emotion, Integer> emotionList;
         private String flowerName;
+        private String flowerImgUrl;
         private Emotion flowerEmotion;
     }
 

--- a/src/main/java/umc/plantory/domain/terrarium/entity/Terrarium.java
+++ b/src/main/java/umc/plantory/domain/terrarium/entity/Terrarium.java
@@ -48,18 +48,15 @@ public class Terrarium {
 
     private LocalDate thirdStepDate;
 
-    private static final int SECOND_STEP = 4;
-    private static final int THIRD_STEP = 7;
+    // 2단계 진입 시 사용
+    public void updateSecondStepDate(LocalDate secondStepDate) {
+        this.secondStepDate = secondStepDate;
+    }
 
-    public void changeFlower(Flower flower) {this.flower = flower;}
-    public void recordStepIfNeeded(int wateringCount, LocalDate now) {
-
-        if (wateringCount == SECOND_STEP && this.secondStepDate == null) {
-            this.secondStepDate = now;
-        } else if (wateringCount == THIRD_STEP && this.thirdStepDate == null) {
-            this.thirdStepDate = now;
-            this.isBloom = true;
-            this.bloomAt = LocalDateTime.now();
-        }
+    // 3단계 진입 시 사용
+    public void updateTerrariumDataForBloom(LocalDate thirdStepDate, LocalDateTime bloomAt) {
+        this.thirdStepDate = thirdStepDate;
+        this.bloomAt = bloomAt;
+        this.isBloom = true;
     }
 }

--- a/src/main/java/umc/plantory/domain/terrarium/service/TerrariumCommandService.java
+++ b/src/main/java/umc/plantory/domain/terrarium/service/TerrariumCommandService.java
@@ -22,11 +22,17 @@ import umc.plantory.global.apiPayload.exception.handler.TerrariumHandler;
 import umc.plantory.global.apiPayload.code.status.ErrorStatus;
 import umc.plantory.global.apiPayload.exception.handler.MemberHandler;
 import umc.plantory.global.apiPayload.exception.GeneralException;
+import umc.plantory.global.apiPayload.exception.handler.WateringCanHandler;
 import umc.plantory.global.enums.Emotion;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -42,116 +48,79 @@ public class TerrariumCommandService implements TerrariumCommandUseCase {
 
     /**
      * 회원의 테라리움을 물주는 작업을 수행합니다.
-     *
-     * @param authorization 인증용 JWT 토큰
-     * @param terrariumId   현재 키우고 있는 중인 테라리움 id
      */
     @Override
     @Transactional
     public TerrariumResponseDto.WateringTerrariumResponse performTerrariumWatering(String authorization, Long terrariumId) {
-
-        String token = jwtProvider.resolveToken(authorization);
-        if (token == null) {
-            throw new MemberHandler(ErrorStatus._UNAUTHORIZED);
-        }
-        jwtProvider.validateToken(token);
-        Long memberId = jwtProvider.getMemberId(token);
+        Long memberId = jwtProvider.getMemberIdAndValidateToken(authorization);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-
         Terrarium terrarium = terrariumRepository.findById(terrariumId)
                 .orElseThrow(() -> new TerrariumHandler(ErrorStatus.TERRARIUM_NOT_FOUND));
-        // 사용 가능한 물뿌리개 확인 및 WateringCan 개수 검증
-        WateringCan wateringCan = findAvailableWateringCan(memberId);
-        // 물주기 작업 수행
-        try {
-            WateringResult wateringResult = processWatering(member, terrarium, wateringCan);
-            return TerrariumConverter.toWateringTerrariumResponse(
-                    wateringResult.getWateringCount(),
-                    member.getWateringCanCnt(),
-                    wateringResult.emotionCounts
-                    ,terrarium.getFlower());
-        } catch (Exception e) {
-            throw new GeneralException(ErrorStatus.WATERING_PROCESS_FAILED);
-        }
-    }
 
-    // 사용 가능한 물뿌리개 조회 (가장 오래된 일기 기준)
-    private WateringCan findAvailableWateringCan(Long memberId) {
-        List<WateringCan> availableWateringCanList = wateringCanRepository.findUnusedByMemberIdOrderByDiaryCreatedAtAsc(memberId);
-        WateringCan wateringCan = availableWateringCanList.get(0);
-        if (wateringCan == null) {
-            throw new TerrariumHandler(ErrorStatus.NO_AVAILABLE_WATERING_CAN);
-        }
-        return wateringCan;
-    }
+        // 현재 테라리움에 준 물의 수
+        Integer currentWateringCnt = wateringEventRepository.countByTerrarium(terrarium);
 
-    // 물주기 처리 메서드
-    private WateringResult processWatering(Member member, Terrarium terrarium, WateringCan wateringCan) {
-        // WateringCan 개수 차감 후 저장
+        // 사용할 물뿌리개 조회
+        WateringCan selectedWateringCan = wateringCanRepository.findSelectedWateringCan(member)
+                .orElseThrow(() -> new WateringCanHandler(ErrorStatus.NO_AVAILABLE_WATERING_CAN));
+
+        // 물 사용 -> 해당 멤버의 물 Count - 1
         member.decreaseWateringCan();
+        currentWateringCnt++;
 
-        // 새로운 WateringEvent 생성 및 저장 후 즉시 DB 반영
-        WateringEvent wateringEvent = WateringEventConverter.toWateringEvent(wateringCan, terrarium);
-        wateringEventRepository.save(wateringEvent);
-        wateringEventRepository.flush();
+        if (currentWateringCnt == 3) {
+            // 사용한 물뿌리개 저장
+            saveNewWateringEvent(selectedWateringCan, terrarium);
 
-        // 현재 테라리움에 대한 물주기 횟수 집계 및 단계 기록
-        int TerrariumwateringCount = wateringEventRepository.countByTerrariumId(terrarium.getId());
-        terrarium.recordStepIfNeeded(TerrariumwateringCount, LocalDate.now());
+            // 2번째 단계 시간 업데이트
+            terrarium.updateSecondStepDate(LocalDate.now());
+            return TerrariumConverter.toDefaultWateringTerrariumResponse(currentWateringCnt, member.getWateringCanCnt());
+        } else if (currentWateringCnt == 7) {
+            // 사용한 물뿌리개 저장
+            saveNewWateringEvent(selectedWateringCan, terrarium);
 
-        List<Object[]> emotionCounts = Collections.emptyList();
-        // 7단계(꽃나무 단계) 도달 시 응답 형식이 달라야 하기 때문에 emotionCounts 생성
-        if (TerrariumwateringCount >= 7) {
-            emotionCounts = wateringEventRepository.findEmotionCountsByTerrariumId(terrarium.getId());
-
-            if (!emotionCounts.isEmpty()) {
-                Emotion mostEmotion = (Emotion) emotionCounts.get(0)[0];
-
-                Flower flowerForMostEmotion = flowerRepository.findByEmotion(mostEmotion);
-
-                // 테라리움의 꽃 변경
-                terrarium.changeFlower(flowerForMostEmotion);
-            }
-            // 새로운 테라리움 생성
+            // 3번째 단계 진입 시 업데이트 필요한 데이터 업데이트
+            terrarium.updateTerrariumDataForBloom(LocalDate.now(), LocalDateTime.now());
             member.increaseTotalBloomCnt();
-            createNewTerrarium(member);
-        }
 
-        memberRepository.save(member);
-        terrariumRepository.save(terrarium);
-        terrariumRepository.flush();
+            // 꽃 피는 부분 데이터 가져오는 로직 필요
+            List<WateringEvent> wateringEventList = wateringEventRepository.findAllByTerrarium(terrarium);
 
-        return new WateringResult(TerrariumwateringCount, emotionCounts);
-    }
+            Map<Emotion, Integer> emotionList = new HashMap<>();
+            for (WateringEvent wateringEvent : wateringEventList) {
+                Emotion emotion = wateringEvent.getWateringCan().getEmotion();
 
-    // 신규 테라리움 생성
-    private void createNewTerrarium(Member member) {
-        Flower baseflower = flowerRepository.findByEmotion(Emotion.DEFAULT);
+                // 해당 감정이 있으면 값 + 1, 없으면 1 PUT
+                emotionList.put(emotion, emotionList.getOrDefault(emotion, 0) + 1);
+            }
 
-        Terrarium terrariumCurrentIsBloomFalse = terrariumRepository.findByMemberIdAndIsBloomFalse(member.getId());
+            // Map에서 가장 큰 value 저장
+            int maxCount = Collections.max(emotionList.values());
+            // 해당 value 를 갖는 key(감정) List로 저장
+            List<Emotion> mostFrequentEmotions = emotionList.entrySet().stream()
+                    .filter(entry -> entry.getValue() == maxCount)
+                    .map(Map.Entry::getKey)
+                    .toList();
 
-        if (!(terrariumCurrentIsBloomFalse == null)) {
-            throw new TerrariumHandler(ErrorStatus.TERRARIUM_ALREADY_IN_PROGRESS);
+            // 랜덤 1개 선택
+            Emotion randomEmotion = mostFrequentEmotions.get(ThreadLocalRandom.current().nextInt(mostFrequentEmotions.size()));
+            // 해당 감정에 맞는 Flower 선택
+            Flower flower = flowerRepository.findByEmotion(randomEmotion);
+
+            return TerrariumConverter.toBloomWateringTerrariumResponse(currentWateringCnt, member.getWateringCanCnt(), emotionList, flower);
         } else {
-            Terrarium newTerrarium = TerrariumConverter.toTerrarium(member, baseflower);
-            terrariumRepository.save(newTerrarium);
-            log.info("신규 테라리움 생성 - memberId: {}, terrariumId: {}", member.getId(), newTerrarium.getId());
+            // 사용한 물뿌리개 저장
+            saveNewWateringEvent(selectedWateringCan, terrarium);
+
+            return TerrariumConverter.toDefaultWateringTerrariumResponse(currentWateringCnt, member.getWateringCanCnt());
         }
     }
 
-    // 결과 객체
-    public class WateringResult {
-        private final int wateringCount;
-        private final List<Object[]> emotionCounts;
-
-        public WateringResult(int wateringCount, List<Object[]> emotionCounts) {
-            this.wateringCount = wateringCount;
-            this.emotionCounts = emotionCounts;
-        }
-
-        public int getWateringCount() {
-            return wateringCount;
-        }
+    /**
+     * 새로운 물뿌리개 생성 메서드
+     */
+    private WateringEvent saveNewWateringEvent (WateringCan selectedWateringCan, Terrarium terrarium) {
+        return wateringEventRepository.save(WateringEventConverter.toWateringEvent(selectedWateringCan, terrarium));
     }
 }

--- a/src/main/java/umc/plantory/domain/wateringCan/repository/WateringCanRepository.java
+++ b/src/main/java/umc/plantory/domain/wateringCan/repository/WateringCanRepository.java
@@ -1,25 +1,14 @@
 package umc.plantory.domain.wateringCan.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import umc.plantory.domain.diary.entity.Diary;
 import umc.plantory.domain.member.entity.Member;
-import umc.plantory.domain.terrarium.entity.Terrarium;
 import umc.plantory.domain.wateringCan.entity.WateringCan;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 
-public interface WateringCanRepository extends JpaRepository<WateringCan, Long> {
+public interface WateringCanRepository extends JpaRepository<WateringCan, Long>, WateringCanRepositoryCustom {
     Optional<WateringCan> findByDiary(Diary diary);
     boolean existsByDiaryDateAndMember(LocalDate diaryDate, Member member);
-    @Query("SELECT wc FROM WateringCan wc " +
-            "WHERE wc.diary.member.id = :memberId " +
-            "AND NOT EXISTS (" +
-            "SELECT we FROM WateringEvent we " +
-            "WHERE we.wateringCan = wc) " +
-            "ORDER BY wc.diary.createdAt ASC")
-    List<WateringCan> findUnusedByMemberIdOrderByDiaryCreatedAtAsc(@Param("memberId") Long memberId);
 }

--- a/src/main/java/umc/plantory/domain/wateringCan/repository/WateringCanRepositoryCustom.java
+++ b/src/main/java/umc/plantory/domain/wateringCan/repository/WateringCanRepositoryCustom.java
@@ -1,0 +1,10 @@
+package umc.plantory.domain.wateringCan.repository;
+
+import umc.plantory.domain.member.entity.Member;
+import umc.plantory.domain.wateringCan.entity.WateringCan;
+
+import java.util.Optional;
+
+public interface WateringCanRepositoryCustom {
+    Optional<WateringCan> findSelectedWateringCan(Member member);
+}

--- a/src/main/java/umc/plantory/domain/wateringCan/repository/WateringCanRepositoryImpl.java
+++ b/src/main/java/umc/plantory/domain/wateringCan/repository/WateringCanRepositoryImpl.java
@@ -1,0 +1,45 @@
+package umc.plantory.domain.wateringCan.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import umc.plantory.domain.member.entity.Member;
+import umc.plantory.domain.wateringCan.entity.QWateringCan;
+import umc.plantory.domain.wateringCan.entity.QWateringEvent;
+import umc.plantory.domain.wateringCan.entity.WateringCan;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class WateringCanRepositoryImpl implements WateringCanRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<WateringCan> findSelectedWateringCan(Member member) {
+        QWateringCan wateringCan = QWateringCan.wateringCan;
+        QWateringEvent wateringEvent = QWateringEvent.wateringEvent;
+
+        // 조건 1. Member 일치
+        // 조건 2. 조건 1과 일치하는 WateringCan 중 WateringEvent에 있지 않은 WateringCan
+        BooleanBuilder builder = new BooleanBuilder()
+                .and(wateringCan.member.eq(member))
+                .and(
+                        JPAExpressions
+                                .selectOne()
+                                .from(wateringEvent)
+                                .where(wateringEvent.wateringCan.eq(wateringCan))
+                                .notExists()
+                );
+
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(wateringCan)
+                        .where(builder)
+                        .orderBy(wateringCan.diaryDate.asc())
+                        .fetchFirst()
+        );
+    }
+}

--- a/src/main/java/umc/plantory/domain/wateringCan/repository/WateringEventRepository.java
+++ b/src/main/java/umc/plantory/domain/wateringCan/repository/WateringEventRepository.java
@@ -11,17 +11,8 @@ import java.util.List;
 
 public interface WateringEventRepository extends JpaRepository<WateringEvent, Long> {
     int countByTerrariumId(Long terrariumId);
-    @Query("SELECT wc.emotion, COUNT(wc.emotion) as cnt " +
-            "FROM WateringEvent we " +
-            "JOIN we.wateringCan wc " +
-            "WHERE we.terrarium.id = :terrariumId " +
-            "GROUP BY wc.emotion " +
-            "ORDER BY cnt DESC")
-    List<Object[]> findEmotionCountsByTerrariumId(@Param("terrariumId") Long terrariumId);
     @Query("SELECT we.wateringCan FROM WateringEvent we WHERE we.terrarium.id = :terrariumId")
     List<WateringCan> findWateringCanListByTerrariumId(@Param("terrariumId") Long terrariumId);
-  
-    // 특정 테라리움의 물 준 횟수 계산 (JPA 메서드명으로 자동 생성)
     Integer countByTerrarium(Terrarium terrarium);
-
+    List<WateringEvent> findAllByTerrarium(Terrarium terrarium);
 }

--- a/src/main/java/umc/plantory/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/plantory/global/apiPayload/code/status/ErrorStatus.java
@@ -77,6 +77,7 @@ public enum ErrorStatus implements BaseErrorCode {
     TERRARIUM_NOT_BLOOMED(HttpStatus.BAD_REQUEST, "TERRARIUM4002", "아직 개화하지 않은 테라리움입니다."),
     NO_COMPLETED_TERRARIUM_IN_MONTH(HttpStatus.NOT_FOUND, "TERRARIUM4044", "해당 월에 개화 완료된 테라리움이 없습니다."),
     TERRARIUM_ALREADY_IN_PROGRESS(HttpStatus.BAD_REQUEST, "TERRARIUM4003", "이미 진행 중인 테라리움이 존재합니다."),
+    ALREADY_BLOOMED_TERRARIUM(HttpStatus.BAD_REQUEST, "TERRARIUM4004", "이미 개화한 테라리움입니다."),
 
     // 물주기 관련
     WATERING_PROCESS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "W4001", "물 주기에 실패했습니다."),

--- a/src/main/java/umc/plantory/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/plantory/global/apiPayload/code/status/ErrorStatus.java
@@ -78,6 +78,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NO_COMPLETED_TERRARIUM_IN_MONTH(HttpStatus.NOT_FOUND, "TERRARIUM4044", "해당 월에 개화 완료된 테라리움이 없습니다."),
     TERRARIUM_ALREADY_IN_PROGRESS(HttpStatus.BAD_REQUEST, "TERRARIUM4003", "이미 진행 중인 테라리움이 존재합니다."),
     ALREADY_BLOOMED_TERRARIUM(HttpStatus.BAD_REQUEST, "TERRARIUM4004", "이미 개화한 테라리움입니다."),
+    WATERING_CNT_INCORRECT(HttpStatus.INTERNAL_SERVER_ERROR, "TERRARIUM4005", "물 준 횟수가 불일치 합니다. (데이터 문제 발생. 문의 필요)"),
 
     // 물주기 관련
     WATERING_PROCESS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "W4001", "물 주기에 실패했습니다."),

--- a/src/main/java/umc/plantory/global/apiPayload/exception/handler/WateringCanHandler.java
+++ b/src/main/java/umc/plantory/global/apiPayload/exception/handler/WateringCanHandler.java
@@ -1,0 +1,10 @@
+package umc.plantory.global.apiPayload.exception.handler;
+
+import umc.plantory.global.apiPayload.code.BaseErrorCode;
+import umc.plantory.global.apiPayload.exception.GeneralException;
+
+public class WateringCanHandler extends GeneralException {
+    public WateringCanHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약
- 물 주기 이벤트 API 전체적인 로직 수정

## 🔗 2. 관련 이슈
- CLoses #78 

## 🛠 3. 구현 내용 및 상세
- 물 주기 이벤트 체크해야 되는 부분
- [x] 물주기 이벤트 때 Member.wateringCanCnt 감소 확인
- [x] 물주기 이벤트 때 WATERING_EVENT 에 데이터 들어가는 것 확인 
- [x] WATERING_EVENT 테이블에 없고 WATERING_CAN 테이블에 있으면서 가장 diary_date 값이 오래된 데이터를 타깃 wateringCan 으로 가져와서 사용하는 것 확인 
- [x] 3번째 물주기 이벤트 때 TERRARIUM.second_step_date 업데이트 확인 
- [x] 7번째 물주기 이벤트 때 TERRARIUM.third_step_date / TERRARIUM.isBloom / TERRARIUM.bloomAt 업데이트 확인 
- [x] 7번째 물주기 이벤트 때 Member.totalBloomCnt 증가 확인 
- [x] 7번째 물주기 이벤트 때 변경된 응답 확인 
- [x] 7번째 물주기 후 새로운 테라리움 생성 확인 

## 📋 4. 리뷰 요구사항


## 💬 5. 참고 사항 
