### PR TITLE
[#105] 최근 7일 평균 수면 시간 조회 구현

### DIFF
--- a/src/main/java/umc/plantory/domain/diary/dto/DiaryProjectionDTO.java
+++ b/src/main/java/umc/plantory/domain/diary/dto/DiaryProjectionDTO.java
@@ -1,0 +1,17 @@
+package umc.plantory.domain.diary.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+public class DiaryProjectionDTO {
+
+    @Getter
+    @AllArgsConstructor
+    public static class SleepIntervalDTO {
+        private Long memberId;
+        private LocalDateTime sleepStartTime;
+        private LocalDateTime sleepEndTime;
+    }
+}

--- a/src/main/java/umc/plantory/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/umc/plantory/domain/diary/repository/DiaryRepository.java
@@ -2,6 +2,7 @@ package umc.plantory.domain.diary.repository;
 
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import umc.plantory.domain.diary.dto.DiaryProjectionDTO;
 import umc.plantory.domain.diary.entity.Diary;
 import umc.plantory.domain.member.entity.Member;
 import umc.plantory.global.enums.DiaryStatus;
@@ -16,6 +17,8 @@ public interface DiaryRepository extends JpaRepository<Diary, Long>, DiaryReposi
     boolean existsByMemberIdAndDiaryDateAndStatus(Long memberId, LocalDate diaryDate, DiaryStatus status);
     List<Diary> findByMemberAndStatusInAndDiaryDateBetween(Member member, List<DiaryStatus> diaryStatuses, LocalDate start, LocalDate end);
     List<Diary> findAllByMemberIdAndStatus(Long memberId, DiaryStatus status, Sort sort);
-    List<Diary> findByStatusAndTempSavedAtBefore(DiaryStatus status, LocalDateTime threshold);
     List<Diary> findByStatusAndDeletedAtBefore(DiaryStatus status, LocalDateTime threshold);
+    List<DiaryProjectionDTO.SleepIntervalDTO> findByMemberInAndStatusInAndDiaryDateBetween(
+            List<Member> members, List<DiaryStatus> statuses, LocalDate start, LocalDate end
+    );
 }

--- a/src/main/java/umc/plantory/domain/diary/repository/DiaryRepositoryCustom.java
+++ b/src/main/java/umc/plantory/domain/diary/repository/DiaryRepositoryCustom.java
@@ -2,7 +2,6 @@ package umc.plantory.domain.diary.repository;
 
 import umc.plantory.domain.diary.dto.DiaryRequestDTO;
 import umc.plantory.domain.diary.entity.Diary;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/umc/plantory/domain/diary/service/DiaryCommandService.java
+++ b/src/main/java/umc/plantory/domain/diary/service/DiaryCommandService.java
@@ -26,9 +26,12 @@ import umc.plantory.global.apiPayload.exception.handler.MemberHandler;
 import umc.plantory.global.enums.DiaryStatus;
 import umc.plantory.global.enums.Emotion;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static umc.plantory.global.enums.DiaryStatus.VALID_STATUSES;
 
 /**
  * 일기 작성 관련 커맨드(등록/수정 등) 비즈니스 로직을 처리하는 서비스
@@ -64,11 +67,11 @@ public class DiaryCommandService implements DiaryCommandUseCase {
         diaryRepository.save(diary);
         String imageUrl = handleDiaryImage(diary, request.getDiaryImgUrl(), false);
 
-        // NORMAL 상태일 경우 누적 감정 기록 횟수 증가
-        // 당일 작성한 일기일 경우 연속 기록 & 물뿌리개 +1
+        // NORMAL 상태일 경우 누적 감정 기록 횟수, 연속 기록, 평균 수면 시간, 물뿌리개 처리
         if (diary.getStatus() == DiaryStatus.NORMAL) {
             member.increaseTotalRecordCnt();
             handleContinuousRecordCnt(diary, member);
+            handleAvgSleepTime(member, diary.getDiaryDate());
             handleWateringCan(diary, member);
 
         // TEMP 상태일 경우 tempSavedAt 기록
@@ -123,11 +126,11 @@ public class DiaryCommandService implements DiaryCommandUseCase {
         if (status == DiaryStatus.TEMP) {
             diary.updateTempSavedAt(LocalDateTime.now());
 
-        // TEMP → NORMAL 상태일 경우 누적 감정 기록 횟수 증가
-        // 당일 작성한 일기일 경우 연속 기록 & 물뿌리개 +1
+        // TEMP → NORMAL 상태일 경우 누적 감정 기록 횟수, 연속 기록, 평균 수면 시간, 물뿌리개 처리
         } else if (beforeStatus == DiaryStatus.TEMP && status == DiaryStatus.NORMAL) {
             member.increaseTotalRecordCnt();
             handleContinuousRecordCnt(diary, member);
+            handleAvgSleepTime(member, diary.getDiaryDate());
             handleWateringCan(diary, member);
         }
 
@@ -201,6 +204,9 @@ public class DiaryCommandService implements DiaryCommandUseCase {
 
             diary.updateStatus(DiaryStatus.TEMP);
 
+            // 평균 수면 시간 업데이트
+            handleAvgSleepTime(member, diary.getDiaryDate());
+
             // tempSavedAt 기록
             diary.updateTempSavedAt(LocalDateTime.now());
         }
@@ -228,6 +234,9 @@ public class DiaryCommandService implements DiaryCommandUseCase {
             }
 
             diary.updateStatus(DiaryStatus.DELETE);
+
+            // 평균 수면 시간 업데이트
+            handleAvgSleepTime(member, diary.getDiaryDate());
 
             // deletedAt 기록
             diary.updateDeletedAt(LocalDateTime.now());
@@ -348,6 +357,29 @@ public class DiaryCommandService implements DiaryCommandUseCase {
             // 마지막으로 작성한 일기 날짜 업데이트
             member.updateLastDiaryDate(diary.getDiaryDate());
         }
+    }
+
+    // 최근 7일 수면 시간 처리
+    private void handleAvgSleepTime(Member member, LocalDate diaryDate) {
+        LocalDate today = LocalDate.now();
+        LocalDate start = today.minusDays(6);
+
+        // 작성한 일기가 최근 7일 범위에 들어오는지 확인
+        if (diaryDate.isBefore(start) || diaryDate.isAfter(today)) {
+            return;
+        }
+
+        // 최근 7일 일기 조회
+        List<Diary> diaries = diaryRepository.findByMemberAndStatusInAndDiaryDateBetween(
+                member, VALID_STATUSES, start, today
+        );
+
+        // 평균 수면 시간 계산 및 업데이트
+        int totalMinutes = 0;
+        for (Diary d : diaries) {
+            totalMinutes += (int) Duration.between(d.getSleepStartTime(), d.getSleepEndTime()).toMinutes();
+        }
+        member.updateAvgSleepTime(totalMinutes / diaries.size());
     }
 
     // 물뿌리개 지급

--- a/src/main/java/umc/plantory/domain/diary/service/DiaryCommandService.java
+++ b/src/main/java/umc/plantory/domain/diary/service/DiaryCommandService.java
@@ -364,7 +364,7 @@ public class DiaryCommandService implements DiaryCommandUseCase {
         LocalDate today = LocalDate.now();
         LocalDate start = today.minusDays(6);
 
-        // 작성한 일기가 최근 7일 범위에 들어오는지 확인
+        // 일기가 최근 7일 범위에 들어오는지 확인
         if (diaryDate.isBefore(start) || diaryDate.isAfter(today)) {
             return;
         }
@@ -373,6 +373,12 @@ public class DiaryCommandService implements DiaryCommandUseCase {
         List<Diary> diaries = diaryRepository.findByMemberAndStatusInAndDiaryDateBetween(
                 member, VALID_STATUSES, start, today
         );
+
+        // 조회된 일기가 없으면 수면 시간 0으로 업데이트
+        if (diaries.isEmpty()) {
+            member.updateAvgSleepTime(0);
+            return;
+        }
 
         // 평균 수면 시간 계산 및 업데이트
         int totalMinutes = 0;

--- a/src/main/java/umc/plantory/domain/member/entity/Member.java
+++ b/src/main/java/umc/plantory/domain/member/entity/Member.java
@@ -133,4 +133,8 @@ public class Member extends BaseEntity {
     public void updateLastDiaryDate(LocalDate lastDiaryDate) {
         this.lastDiaryDate = lastDiaryDate;
     }
+
+    public void updateAvgSleepTime(int minutes) {
+        this.avgSleepTime = minutes;
+    }
 }

--- a/src/main/java/umc/plantory/domain/member/repository/MemberRepository.java
+++ b/src/main/java/umc/plantory/domain/member/repository/MemberRepository.java
@@ -4,12 +4,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.plantory.domain.member.entity.Member;
+import umc.plantory.global.enums.MemberStatus;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom{
     Optional<Member> findByProviderId(String sub);
     @Query("SELECT m.nickname FROM Member m WHERE m.id = :memberId")
     String findNicknameById(@Param("memberId") Long memberId);
-
+    List<Member> findAllByStatus(MemberStatus status);
 }

--- a/src/main/java/umc/plantory/global/scheduler/Scheduler.java
+++ b/src/main/java/umc/plantory/global/scheduler/Scheduler.java
@@ -16,5 +16,6 @@ public class Scheduler {
         schedulerJob.resetContinuousRecordCnt();
         schedulerJob.updateTempToDeleted();
         schedulerJob.deleteDiariesPermanently();
+        schedulerJob.updateAvgSleepTime();
     }
 }

--- a/src/main/java/umc/plantory/global/scheduler/SchedulerJob.java
+++ b/src/main/java/umc/plantory/global/scheduler/SchedulerJob.java
@@ -4,20 +4,28 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import umc.plantory.domain.diary.dto.DiaryProjectionDTO;
 import umc.plantory.domain.diary.entity.Diary;
 import umc.plantory.domain.diary.entity.DiaryImg;
 import umc.plantory.domain.diary.repository.DiaryImgRepository;
 import umc.plantory.domain.diary.repository.DiaryRepository;
 import umc.plantory.domain.image.service.ImageUseCase;
+import umc.plantory.domain.member.entity.Member;
 import umc.plantory.domain.member.repository.MemberRepository;
 import umc.plantory.domain.wateringCan.entity.WateringCan;
 import umc.plantory.domain.wateringCan.repository.WateringCanRepository;
 import umc.plantory.global.enums.DiaryStatus;
+import umc.plantory.global.enums.MemberStatus;
 
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static umc.plantory.global.enums.DiaryStatus.VALID_STATUSES;
 
 @Component
 @RequiredArgsConstructor
@@ -35,15 +43,14 @@ public class SchedulerJob {
      */
     @Transactional
     public void updateTempToDeleted() {
-        LocalDateTime start = LocalDateTime.now();
         log.info("[스케줄러] TEMP → DELETE 작업 시작");
 
         try {
+            LocalDateTime now = LocalDateTime.now();
             LocalDate threshold = LocalDate.now().minusDays(30);
-            long updatedCount = diaryRepository.bulkUpdateTempToDeleted(threshold, start);
+            long updatedCount = diaryRepository.bulkUpdateTempToDeleted(threshold, now);
 
-            Duration duration = Duration.between(start, LocalDateTime.now());
-            log.info("[스케줄러] TEMP → DELETE 처리 완료 | 대상: {}건 | 소요 시간: {}ms", updatedCount, duration.toMillis());
+            log.info("[스케줄러] TEMP → DELETE 처리 완료 | 대상: {}건", updatedCount);
         } catch (Exception e) {
             log.error("[스케줄러] TEMP → DELETE 처리 실패", e);
         }
@@ -54,7 +61,6 @@ public class SchedulerJob {
      */
     @Transactional
     public void deleteDiariesPermanently() {
-        LocalDateTime start = LocalDateTime.now();
         log.info("[스케줄러] DELETE → 영구 삭제 작업 시작");
 
         try {
@@ -82,8 +88,7 @@ public class SchedulerJob {
             // 일기 삭제
             diaryRepository.deleteAll(deletedDiaries);
 
-            Duration duration = Duration.between(start, LocalDateTime.now());
-            log.info("[스케줄러] DELETE → 영구 삭제 처리 완료 | 대상: {}건 | 소요 시간: {}ms", deletedDiaries.size(), duration.toMillis());
+            log.info("[스케줄러] DELETE → 영구 삭제 처리 완료 | 대상: {}건", deletedDiaries.size());
         } catch (Exception e) {
             log.error("[스케줄러] DELETE → 영구 삭제 처리 실패", e);
         }
@@ -94,17 +99,67 @@ public class SchedulerJob {
      */
     @Transactional
     public void resetContinuousRecordCnt() {
-        LocalDateTime start = LocalDateTime.now();
         log.info("[스케줄러] 연속 기록 초기화 시작");
 
         try {
             LocalDate yesterday = LocalDate.now().minusDays(1);
             long updatedCount = memberRepository.bulkUpdateContinuousRecordCnt(yesterday);
 
-            Duration duration = Duration.between(start, LocalDateTime.now());
-            log.info("[스케줄러] 연속 기록 초기화 완료 | 대상: {}건 | 소요 시간: {}ms", updatedCount, duration.toMillis());
+            log.info("[스케줄러] 연속 기록 초기화 완료 | 대상: {}명", updatedCount);
         } catch (Exception e) {
             log.error("[스케줄러] 연속 기록 초기화 실패", e);
+        }
+    }
+
+    /**
+     * 매일 자정 00:00에 최근 7일 평균 수면 시간 갱신
+     */
+    @Transactional
+    public void updateAvgSleepTime() {
+        log.info("[스케줄러] 최근 7일 평균 수면 시간 갱신 시작");
+
+        try {
+            LocalDate today = LocalDate.now();
+            LocalDate start = today.minusDays(6);
+
+            // ACTIVE 상태의 유저 조회
+            List<Member> members = memberRepository.findAllByStatus(MemberStatus.ACTIVE);
+
+            // 유저들의 최근 7일간 일기에서 수면 시작 시각과 수면 종료 시각을 한 번에 조회
+            List<DiaryProjectionDTO.SleepIntervalDTO> intervals =
+                    diaryRepository.findByMemberInAndStatusInAndDiaryDateBetween(members, VALID_STATUSES, start, today);
+
+            // 유저별로 수면 데이터 그룹핑
+            Map<Long, List<DiaryProjectionDTO.SleepIntervalDTO>> SleepIntervalByMemberId = intervals.stream()
+                    .collect(Collectors.groupingBy(DiaryProjectionDTO.SleepIntervalDTO::getMemberId));
+
+            int updatedCount = 0;
+
+            // 각 유저에 대해 평균 수면 시간을 계산하고 필요 시 업데이트
+            for (Member member : members) {
+                List<DiaryProjectionDTO.SleepIntervalDTO> rows = SleepIntervalByMemberId.getOrDefault(member.getId(), Collections.emptyList());
+
+                // 평균 수면 시간 계산
+                int newAvg = 0;
+                if (!rows.isEmpty()) {
+                    int totalMinutes = 0;
+                    for (DiaryProjectionDTO.SleepIntervalDTO r : rows) {
+                        totalMinutes += (int) Duration.between(r.getSleepStartTime(), r.getSleepEndTime()).toMinutes();
+                    }
+                    newAvg = totalMinutes / rows.size();
+                }
+
+                // 평균 수면 시간 업데이트
+                if (member.getAvgSleepTime() != newAvg) {
+                    member.updateAvgSleepTime(newAvg);
+                    updatedCount++;
+                }
+            }
+
+            log.info("[스케줄러] 최근 7일 평균 수면시간 갱신 완료 | 대상: {}명", updatedCount);
+
+        } catch (Exception e) {
+            log.error("[스케줄러] 최근 7일 평균 수면시간 갱신 실패", e);
         }
     }
 }

--- a/src/main/java/umc/plantory/global/scheduler/SchedulerJob.java
+++ b/src/main/java/umc/plantory/global/scheduler/SchedulerJob.java
@@ -130,14 +130,14 @@ public class SchedulerJob {
                     diaryRepository.findByMemberInAndStatusInAndDiaryDateBetween(members, VALID_STATUSES, start, today);
 
             // 유저별로 수면 데이터 그룹핑
-            Map<Long, List<DiaryProjectionDTO.SleepIntervalDTO>> SleepIntervalByMemberId = intervals.stream()
+            Map<Long, List<DiaryProjectionDTO.SleepIntervalDTO>> sleepIntervalByMemberId = intervals.stream()
                     .collect(Collectors.groupingBy(DiaryProjectionDTO.SleepIntervalDTO::getMemberId));
 
             int updatedCount = 0;
 
             // 각 유저에 대해 평균 수면 시간을 계산하고 필요 시 업데이트
             for (Member member : members) {
-                List<DiaryProjectionDTO.SleepIntervalDTO> rows = SleepIntervalByMemberId.getOrDefault(member.getId(), Collections.emptyList());
+                List<DiaryProjectionDTO.SleepIntervalDTO> rows = sleepIntervalByMemberId.getOrDefault(member.getId(), Collections.emptyList());
 
                 // 평균 수면 시간 계산
                 int newAvg = 0;


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약
- 마이페이지 - 평균 수면 시간 기능 구현

## 🔗 2. 관련 이슈
- Closes #105 

## 🛠 3. 구현 내용 및 상세
- 일기 작성/수정/임시보관/삭제 시 최근 7일 평균 수면 시간 업데이트
    - 해당 일기가 최근 7일 내 범위에 들어오는 경우 최근 7일 평균 수면 시간 계산, 업데이트 

- 최근 7일 평균 수면 시간 업데이트 스케줄러 구현
    - 매일 자정 ACTIVE 상태 유저들의 최근 7일 평균 수면 시간을 계산, 업데이트
    - Diary에서 memberId, sleepStartTime, sleepEndTime만 조회하기 위해 jpa에서 projection 사용
    - 유저들의 수면 정보를 한번에 조회 → 유저별로 그룹핑 → 평균 수면 시간 계산 → 기존의 수면 시간과 다른 경우 업데이트 

## 📋 4. 리뷰 요구사항
- 수면 정보를 가져올때 projection을 위해 `DiaryProjectionDTO`를 만들었는데 클래스 위치나 네이밍이 괜찮은지 확인해주세요!
