### PR TITLE
[#120] 내용 없이 일기 임시 저장 시, 임시 제목 부여

### DIFF
--- a/src/main/java/umc/plantory/domain/diary/service/DiaryCommandService.java
+++ b/src/main/java/umc/plantory/domain/diary/service/DiaryCommandService.java
@@ -367,6 +367,7 @@ public class DiaryCommandService implements DiaryCommandUseCase {
 
     // 프롬프트 생성 및 AI 호출 후, 제목 응답 받기
     private String generateDiaryTitle(String content) {
+        if (content == null) return "임시 제목";
         Prompt prompt = PromptFactory.buildDiaryTitlePrompt(content);
         return aiClient.getResponse(prompt);
     }


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약
사용자가 감정만 기록한 후, 일기를 임시저장 한 경우 임시 제목으로 저장

## 🔗 2. 관련 이슈
- Closes #120 

## 🛠 3. 구현 내용 및 상세
요청 본문에 content가 null인 경우, 제목 생성 시, ai 호출 없이 임시 제목으로 저장

## 📋 4. 리뷰 요구사항]

## 💬 5. 참고 사항 
