### PR TITLE
[#129] 예외처리 추가 및 초기 데이터 생성 위치 변경

### DIFF
--- a/src/main/java/umc/plantory/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/umc/plantory/domain/diary/repository/DiaryRepository.java
@@ -21,4 +21,5 @@ public interface DiaryRepository extends JpaRepository<Diary, Long>, DiaryReposi
     List<DiaryProjectionDTO.SleepIntervalDTO> findByMemberInAndStatusInAndDiaryDateBetween(
             List<Member> members, List<DiaryStatus> statuses, LocalDate start, LocalDate end
     );
+    boolean existsByMemberAndDiaryDate(Member member, LocalDate diaryDate);
 }

--- a/src/main/java/umc/plantory/domain/diary/service/DiaryCommandService.java
+++ b/src/main/java/umc/plantory/domain/diary/service/DiaryCommandService.java
@@ -59,6 +59,13 @@ public class DiaryCommandService implements DiaryCommandUseCase {
     public DiaryResponseDTO.DiaryInfoDTO saveDiary(String authorization, DiaryRequestDTO.DiaryUploadDTO request) {
         Member member = getLoginMember(authorization);
 
+        // 요청으로 들어온 날짜에 이미 작성된 일기가 있는지 확인
+        LocalDate diaryDate = request.getDiaryDate();
+        if (diaryRepository.existsByMemberAndDiaryDate(member, diaryDate)) throw new DiaryHandler(ErrorStatus.DUPLICATE_DIARY_DATE);
+
+        // 일기 날짜가 오늘 날짜보다 미래인지 확인
+        if (diaryDate.isAfter(LocalDate.now())) throw new DiaryHandler(ErrorStatus.CANNOT_UPLOAD_FUTURE_DIARY);
+
         // 일기 제목 생성
         String diaryTitle = generateDiaryTitle(request.getContent());
 

--- a/src/main/java/umc/plantory/domain/terrarium/repository/TerrariumRepository.java
+++ b/src/main/java/umc/plantory/domain/terrarium/repository/TerrariumRepository.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 
 public interface TerrariumRepository extends JpaRepository<Terrarium, Long> {
     Optional<Terrarium> findByMemberAndIsBloomFalse(Member member);
-
     Terrarium findByMemberIdAndIsBloomFalse(Long memberId);
     Optional<Terrarium> findByIdAndIsBloomTrue(Long terrariumId);
     @Query("SELECT t FROM Terrarium t " +

--- a/src/main/java/umc/plantory/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/plantory/global/apiPayload/code/status/ErrorStatus.java
@@ -61,6 +61,8 @@ public enum ErrorStatus implements BaseErrorCode {
     DIARY_MISSING_FIELDS(HttpStatus.BAD_REQUEST, "DIARY4002", "일기의 필수 항목이 누락되었습니다."),
     DIARY_UNAUTHORIZED(HttpStatus.FORBIDDEN, "DIARY4003", "해당 일기에 대한 권한이 없습니다."),
     DIARY_INVALID_STATUS(HttpStatus.BAD_REQUEST, "DIARY4004", "현재 일기의 상태에서는 해당 작업을 수행할 수 없습니다."),
+    DUPLICATE_DIARY_DATE(HttpStatus.BAD_REQUEST, "DIARY4005", "해당 날짜에 이미 작성중이거나 작성된 일기가 존재합니다."),
+    CANNOT_UPLOAD_FUTURE_DIARY(HttpStatus.BAD_REQUEST, "DIARY4006", "미래 일기는 작성할 수 없습니다."),
 
     // 채팅 관련
     INVALID_API_KEY(HttpStatus.UNAUTHORIZED, "CHAT4001", "API 키가 잘못됐습니다."),


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약
- 첫 회원가입 시 멤버 데이터 생성하면서 테라리움 데이터도 생성
- 일기 작성 시 해당 날짜에 작성된 일기 있는지 예외 처리
- 일기 작성 시 요청으로 들어온 날짜가 오늘 날짜보다 미래인지 확인 및 예외 처리

## 🔗 2. 관련 이슈
- Closes #129 

## 🛠 3. 구현 내용 및 상세
- 첫 회원가입 시 멤버 데이터 생성하면서 테라리움 데이터도 생성
- 일기 작성 시 해당 날짜에 작성된 일기 있는지 예외 처리
- 일기 작성 시 요청으로 들어온 날짜가 오늘 날짜보다 미래인지 확인 및 예외 처리

## 📋 4. 리뷰 요구사항


## 💬 5. 참고 사항 

