### PR TITLE
[#131] 데모데이 시연용 더미 데이터 입력 자동화

### DIFF
--- a/src/main/java/umc/plantory/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/umc/plantory/domain/diary/repository/DiaryRepository.java
@@ -22,4 +22,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long>, DiaryReposi
             List<Member> members, List<DiaryStatus> statuses, LocalDate start, LocalDate end
     );
     boolean existsByMemberAndDiaryDate(Member member, LocalDate diaryDate);
+    // 데모데이용 - 삭제 예정
+    int countByMember(Member member);
 }

--- a/src/main/java/umc/plantory/domain/member/entity/Member.java
+++ b/src/main/java/umc/plantory/domain/member/entity/Member.java
@@ -137,4 +137,11 @@ public class Member extends BaseEntity {
     public void updateAvgSleepTime(int minutes) {
         this.avgSleepTime = minutes;
     }
+
+    // 데모데이용 - 삭제 예정
+    public void updateMemberDataForDemoDay() {
+        this.continuousRecordCnt = 30;
+        this.wateringCanCnt = 30;
+        this.totalRecordCnt = 30;
+    }
 }

--- a/src/main/java/umc/plantory/domain/member/event/MemberEvent.java
+++ b/src/main/java/umc/plantory/domain/member/event/MemberEvent.java
@@ -1,0 +1,14 @@
+package umc.plantory.domain.member.event;
+
+import lombok.Getter;
+import umc.plantory.domain.member.entity.Member;
+
+// 데모데이용 - 삭제 예정
+@Getter
+public class MemberEvent {
+    private final Long memberId;
+
+    public MemberEvent(Member member) {
+        this.memberId = member.getId();
+    }
+}

--- a/src/main/java/umc/plantory/domain/member/event/OnboardingListener.java
+++ b/src/main/java/umc/plantory/domain/member/event/OnboardingListener.java
@@ -1,30 +1,19 @@
 package umc.plantory.domain.member.event;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
-import umc.plantory.domain.diary.repository.DiaryRepository;
-import umc.plantory.domain.member.repository.MemberRepository;
-import umc.plantory.domain.wateringCan.repository.WateringCanRepository;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OnboardingListener {
-    private static final int DUMMY_COUNT = 30;
-
-    private final MemberRepository memberRepository;
-    private final DiaryRepository diaryRepository;
-    private final WateringCanRepository wateringCanRepository;
+    private final OnboardingService onboardingService;
 
     @Async // 비동기 처리 (대량 추가라 가입 API 응답 지연 최소화를 위함)
-    @Transactional
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // 회원 저장 및 테라리움 생성 쿼리 커밋 후 실행
-    public void createDummyData(Member)
-
-
+    public void createDummyData(MemberEvent event) {
+        onboardingService.createDummyData(event.getMemberId());
+    }
 }

--- a/src/main/java/umc/plantory/domain/member/event/OnboardingListener.java
+++ b/src/main/java/umc/plantory/domain/member/event/OnboardingListener.java
@@ -1,0 +1,30 @@
+package umc.plantory.domain.member.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import umc.plantory.domain.diary.repository.DiaryRepository;
+import umc.plantory.domain.member.repository.MemberRepository;
+import umc.plantory.domain.wateringCan.repository.WateringCanRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OnboardingListener {
+    private static final int DUMMY_COUNT = 30;
+
+    private final MemberRepository memberRepository;
+    private final DiaryRepository diaryRepository;
+    private final WateringCanRepository wateringCanRepository;
+
+    @Async // 비동기 처리 (대량 추가라 가입 API 응답 지연 최소화를 위함)
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // 회원 저장 및 테라리움 생성 쿼리 커밋 후 실행
+    public void createDummyData(Member)
+
+
+}

--- a/src/main/java/umc/plantory/domain/member/event/OnboardingService.java
+++ b/src/main/java/umc/plantory/domain/member/event/OnboardingService.java
@@ -1,0 +1,115 @@
+package umc.plantory.domain.member.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import umc.plantory.domain.diary.entity.Diary;
+import umc.plantory.domain.diary.repository.DiaryRepository;
+import umc.plantory.domain.member.entity.Member;
+import umc.plantory.domain.member.repository.MemberRepository;
+import umc.plantory.domain.wateringCan.entity.WateringCan;
+import umc.plantory.domain.wateringCan.repository.WateringCanRepository;
+import umc.plantory.global.apiPayload.code.status.ErrorStatus;
+import umc.plantory.global.apiPayload.exception.handler.MemberHandler;
+import umc.plantory.global.enums.DiaryStatus;
+import umc.plantory.global.enums.Emotion;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OnboardingService {
+    private static final int DUMMY_COUNT = 30;
+    private static final Emotion[] emotionList = {
+            Emotion.HAPPY, Emotion.AMAZING, Emotion.SAD, Emotion.ANGRY, Emotion.SOSO
+    };
+
+    private final MemberRepository memberRepository;
+    private final DiaryRepository diaryRepository;
+    private final WateringCanRepository wateringCanRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void createDummyData(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 이미 더미데이터가 있으면 스킵 (중복 방지)
+        int diaryCount = diaryRepository.countByMember(member);
+        if (diaryCount >= DUMMY_COUNT) {
+            log.info("[Onboarding] memberId = {} 기존 더미 {}건 존재 -> 더미 데이터 생성 스킵", member.getId(), diaryCount);
+            return;
+        }
+
+        // 더미 30건 생성
+        List<Diary> dummyDiaryList = new ArrayList<>(DUMMY_COUNT);
+        List<WateringCan> dummyWateringCanList = new ArrayList<>(DUMMY_COUNT);
+
+        // 감정 랜덤 (멤버 ID 기반)
+        Random rnd = new Random(member.getId());
+
+        LocalDate today = LocalDate.now();
+        for (int i = 1; i <= DUMMY_COUNT; i++) {
+            LocalDate date = today.minusDays(i); //
+            Emotion emotion = emotionList[rnd.nextInt(emotionList.length)];
+
+            LocalDateTime sleepStart = randomSleepStart(date);
+            LocalDateTime sleepEnd = randomSleepEnd(date);
+
+            Diary diary = Diary.builder()
+                    .member(member)
+                    .title("데모데이용 일기 " + i)
+                    .content("이곳에 오늘의 기분과 생각을 자유롭게 적어보세요 :)")
+                    .emotion(emotion)
+                    .status(DiaryStatus.NORMAL)
+                    .diaryDate(date)
+                    .sleepStartTime(sleepStart)
+                    .sleepEndTime(sleepEnd)
+                    .build();
+
+            WateringCan wateringCan = WateringCan.builder()
+                    .member(member)
+                    .diary(diary)
+                    .emotion(emotion)
+                    .diaryDate(date)
+                    .build();
+
+            dummyDiaryList.add(diary);
+            dummyWateringCanList.add(wateringCan);
+        }
+
+        diaryRepository.saveAll(dummyDiaryList);
+        wateringCanRepository.saveAll(dummyWateringCanList);
+
+        member.updateMemberDataForDemoDay();
+        memberRepository.save(member);
+
+        log.info("[Onboarding] memberId = {} 더미 일기 {}건 생성 완료", member.getId(), dummyDiaryList.size());
+    }
+
+    private LocalDateTime randomSleepStart(LocalDate baseDate) {
+        LocalDateTime startRange = baseDate.minusDays(1).atTime(22, 0);
+        LocalDateTime endRange = baseDate.atTime(3, 0);
+        return randomDateTimeBetween(startRange, endRange);
+    }
+
+    private LocalDateTime randomSleepEnd(LocalDate baseDate) {
+        LocalDateTime startRange = baseDate.atTime(7, 0);
+        LocalDateTime endRange = baseDate.atTime(12, 0);
+        return randomDateTimeBetween(startRange, endRange);
+    }
+
+    private LocalDateTime randomDateTimeBetween(LocalDateTime start, LocalDateTime end) {
+        long startEpoch = start.atZone(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli();
+        long endEpoch   = end.atZone(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli();
+        long randomEpoch = ThreadLocalRandom.current().nextLong(startEpoch, endEpoch);
+        return LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(randomEpoch), java.time.ZoneId.systemDefault());
+    }
+}

--- a/src/main/java/umc/plantory/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/plantory/domain/member/service/MemberCommandService.java
@@ -15,7 +15,6 @@ import umc.plantory.domain.member.repository.MemberRepository;
 import umc.plantory.domain.member.repository.MemberTermRepository;
 import umc.plantory.domain.term.repository.TermRepository;
 import umc.plantory.domain.terrarium.converter.TerrariumConverter;
-import umc.plantory.domain.terrarium.entity.Terrarium;
 import umc.plantory.domain.terrarium.repository.TerrariumRepository;
 import umc.plantory.domain.token.provider.JwtProvider;
 import umc.plantory.domain.token.repository.MemberTokenRepository;
@@ -284,6 +283,11 @@ public class MemberCommandService implements MemberCommandUseCase {
                     Flower defaultFlower = flowerRepository.findByEmotion(Emotion.DEFAULT);
                     // 새 테라리움 생성
                     terrariumRepository.save(TerrariumConverter.toTerrarium(createdMember, defaultFlower));
+
+                    // 더미데이터 생성
+
+
+
                     return createdMember;
                 });
     }

--- a/src/main/java/umc/plantory/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/plantory/domain/member/service/MemberCommandService.java
@@ -1,6 +1,7 @@
 package umc.plantory.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.plantory.domain.flower.entity.Flower;
@@ -10,6 +11,7 @@ import umc.plantory.domain.member.dto.MemberDataDTO;
 import umc.plantory.domain.member.dto.MemberRequestDTO;
 import umc.plantory.domain.member.dto.MemberResponseDTO;
 import umc.plantory.domain.member.entity.Member;
+import umc.plantory.domain.member.event.MemberEvent;
 import umc.plantory.domain.member.mapping.MemberTerm;
 import umc.plantory.domain.member.repository.MemberRepository;
 import umc.plantory.domain.member.repository.MemberTermRepository;
@@ -37,6 +39,9 @@ public class MemberCommandService implements MemberCommandUseCase {
     private final MemberTokenRepository memberTokenRepository;
     private final TerrariumRepository terrariumRepository;
     private final FlowerRepository flowerRepository;
+
+    // 데모데이용 - 삭제 예정
+    private final ApplicationEventPublisher eventPublisher;
 
     private static final String DEFAULT_PROFILE_IMG_URL = "https://plantory.s3.ap-northeast-2.amazonaws.com/profile/plantory_default_img.png";
 
@@ -284,9 +289,8 @@ public class MemberCommandService implements MemberCommandUseCase {
                     // 새 테라리움 생성
                     terrariumRepository.save(TerrariumConverter.toTerrarium(createdMember, defaultFlower));
 
-                    // 더미데이터 생성
-
-
+                    // 더미데이터 생성 (데모데이용 - 삭제 예정) -> AFTER_COMMIT 리스너가 처리
+                    eventPublisher.publishEvent(new MemberEvent(createdMember));
 
                     return createdMember;
                 });

--- a/src/main/java/umc/plantory/global/config/AsyncConfig.java
+++ b/src/main/java/umc/plantory/global/config/AsyncConfig.java
@@ -1,0 +1,10 @@
+package umc.plantory.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+// 데모데이용 - 삭제 예정
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약
- 회원가입 시 더미 데이터 생성 코드 추가

## 🔗 2. 관련 이슈
- Closes #131 

## 🛠 3. 구현 내용 및 상세
- 회원가입 시 이벤트 발행 → 리스너에서 더미데이터 생성
  - 신규 회원 가입 시 MemberCreatedEvent 발행
  - OnboardingListener가 AFTER_COMMIT 시점에 수신하여 더미 생성
   
- 더미 데이터 규칙
  - 일기 30건 자동 생성 (오늘부터 과거 30일)
  - 제목: 데모데이용 일기 N
  - 감정: 랜덤(HAPPY, SOSO, SAD 등)
  - 수면시간:
   - sleepStartTime: 22:00 ~ 익일 03:00 랜덤
   - sleepEndTime: 익일 07:00 ~ 12:00 랜덤

- 트랜잭션 처리
  - 이벤트는 AFTER_COMMIT + @Async 실행
  - 더미 생성은 REQUIRES_NEW 트랜잭션으로 분리 → 본 가입 트랜잭션과 독립

- 멱등 처리
  - 이미 더미 ≥ 30건 존재 시 생성 스킵

- 최적화
  - JPA saveAll + 배치 옵션(rewriteBatchedStatements=true) 적용
  - 기본 타임존 Asia/Seoul 설정

## 📋 4. 리뷰 요구사항


## 💬 5. 참고 사항 
- 데모데이에 시연용으로 추가한 코드라 추후 삭제할 예정입니다.
- MemberEvent 클래스를 만든 이유는 아래 링크에 있습니다.
https://jungle-friday-d03.notion.site/ID-2568dd1cbf4780d29a4cfa1c5009a19e?source=copy_link
