### PR TITLE
[#135] 유저 프로필 상세 조회 API 구현

### DIFF
--- a/src/main/java/umc/plantory/domain/member/controller/MemberRestController.java
+++ b/src/main/java/umc/plantory/domain/member/controller/MemberRestController.java
@@ -33,6 +33,13 @@ public class MemberRestController {
         return ResponseEntity.ok(ApiResponse.onSuccess(memberQueryUseCase.getProfile(authorization)));
     }
 
+    @GetMapping("/myprofile")
+    @Operation(summary = "마이프로필 조회 API", description = "회원의 상세 프로필 정보를 조회하는 API입니다.")
+    public ResponseEntity<ApiResponse<MemberResponseDTO.MyProfileResponse>> getMyProfile(
+            @RequestHeader(value = "Authorization", required = false) String authorization) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(memberQueryUseCase.getMyProfile(authorization)));
+    }
+
     @PatchMapping("/profile")
     @Operation(summary = "프로필 수정 API", description = "회원의 프로필 정보(닉네임, 사용자 커스텀 ID, 성별, 생년월일, 프로필 이미지, 이메일)를 수정하는 API입니다.")
     public ResponseEntity<ApiResponse<MemberResponseDTO.ProfileUpdateResponse>> updateProfile(

--- a/src/main/java/umc/plantory/domain/member/converter/MemberConverter.java
+++ b/src/main/java/umc/plantory/domain/member/converter/MemberConverter.java
@@ -62,6 +62,18 @@ public class MemberConverter {
                 .build();
     }
 
+    public static MemberResponseDTO.MyProfileResponse toMyProfileResponse(Member member) {
+        return MemberResponseDTO.MyProfileResponse.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .userCustomId(member.getUserCustomId())
+                .gender(member.getGender() != null ? member.getGender().name() : null)
+                .birth(member.getBirth() != null ? member.getBirth().toString() : null)
+                .profileImgUrl(member.getProfileImgUrl() != null ? member.getProfileImgUrl() : DEFAULT_PROFILE_IMG_URL)
+                .email(member.getEmail())
+                .build();
+    }
+
     public static MemberTerm toMemberTerm(Member member, Term term, Boolean isAgree) {
         return MemberTerm.builder()
                 .member(member)

--- a/src/main/java/umc/plantory/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/plantory/domain/member/dto/MemberResponseDTO.java
@@ -64,6 +64,20 @@ public class MemberResponseDTO {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
+    public static class MyProfileResponse {
+        private Long memberId;
+        private String nickname;
+        private String userCustomId;
+        private String gender;
+        private String birth;
+        private String profileImgUrl;
+        private String email;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class KkoOAuth2LoginResponse {
         private String accessToken;
         private String refreshToken;

--- a/src/main/java/umc/plantory/domain/member/service/MemberQueryService.java
+++ b/src/main/java/umc/plantory/domain/member/service/MemberQueryService.java
@@ -47,6 +47,16 @@ public class MemberQueryService implements MemberQueryUseCase {
     }
 
     @Override
+    public MemberResponseDTO.MyProfileResponse getMyProfile(String authorization) {
+        Long memberId = jwtProvider.getMemberIdAndValidateToken(authorization);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        return MemberConverter.toMyProfileResponse(member);
+    }
+
+    @Override
     public MemberResponseDTO.HomeResponse getHome(String authorization, YearMonth yearMonth) {
         // JWT 토큰 검증 및 멤버 ID 추출
         Long memberId = jwtProvider.getMemberIdAndValidateToken(authorization);

--- a/src/main/java/umc/plantory/domain/member/service/MemberQueryUseCase.java
+++ b/src/main/java/umc/plantory/domain/member/service/MemberQueryUseCase.java
@@ -7,4 +7,5 @@ import java.time.YearMonth;
 public interface MemberQueryUseCase {
     MemberResponseDTO.ProfileResponse getProfile(String authorization);
     MemberResponseDTO.HomeResponse getHome(String authorization, YearMonth yearMonth);
+    MemberResponseDTO.MyProfileResponse getMyProfile(String authorization);
 }


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약
- 회원 마이프로필 조회 API(GET /v1/plantory/members/myprofile) 추가

## 🔗 2. 관련 이슈
- #135 

## 🛠 3. 구현 내용 및 상세
- MemberResponseDTO에 MyProfileResponse 추가
  - fields: memberId, nickname, userCustomId, gender, birth, profileImgUrl, email
- MemberConverter toMyProfileResponse 추가
- MemberQueryService#getMyProfile 구현
- MemberRestController에 GET /v1/plantory/members/myprofile 엔드포인트 추가 및 Swagger 문서화


## 📋 4. 리뷰 요구사항


## 💬 5. 참고 사항 
- 프론트 요청 사항으로 유저 프로필 조회 API를 추가하였습니다!
