### PR TITLE
[#144] 회원가입 완료 api 프로필 사진 null 가능 처리

### DIFF
--- a/src/main/java/umc/plantory/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/umc/plantory/domain/member/dto/MemberRequestDTO.java
@@ -37,7 +37,7 @@ public class MemberRequestDTO {
         private Gender gender;
         @NotNull(message = "생년월일은 필수입니다.")
         private LocalDate birth;
-        @NotNull(message = "프로필 이미지는 필수입니다.")
+        // null 가능
         private String profileImgUrl;
     }
 


### PR DESCRIPTION
 📌 Pull Request

## 📖 1. 변경 사항 요약
- 회원가입 완료 API 요청값 중 유저 프로필 사진 null 가능 처리 (내부 코드로 null 처리)

## 🔗 2. 관련 이슈
- Closes #144 

## 🛠 3. 구현 내용 및 상세


## 📋 4. 리뷰 요구사항


## 💬 5. 참고 사항 

