### PR TITLE
[#147] 애플로그인 시 provider 값이 APPLE 이 아닌 KAKAO 가 입력되는 에러 해결

### DIFF
--- a/src/main/java/umc/plantory/domain/member/controller/MemberRestController.java
+++ b/src/main/java/umc/plantory/domain/member/controller/MemberRestController.java
@@ -17,6 +17,7 @@ import umc.plantory.domain.member.service.MemberCommandUseCase;
 import umc.plantory.domain.member.service.MemberQueryUseCase;
 import umc.plantory.domain.token.service.MemberTokenCommandUseCase;
 import umc.plantory.global.apiPayload.ApiResponse;
+import umc.plantory.global.enums.Provider;
 
 @Slf4j
 @RestController
@@ -75,7 +76,7 @@ public class MemberRestController {
         MemberDataDTO.MemberData kakaoMemberData = kakaoOidcService.verifyAndParseIdToken(request);
 
         // id_token 에서 추출한 데이터를 통해 멤버 조회 OR 생성
-        Member findOrCreateMember = memberCommandUseCase.findOrCreateMember(kakaoMemberData);
+        Member findOrCreateMember = memberCommandUseCase.findOrCreateMember(kakaoMemberData, Provider.KAKAO);
 
         // 데모데이용
         log.info("[KKO 로그인 API] ( MemberId = {} ) 카카오 로그인 API 진행완료", findOrCreateMember.getId());
@@ -91,7 +92,7 @@ public class MemberRestController {
         MemberDataDTO.MemberData appleMemberData = appleOidcService.verifyAndParseIdToken(request);
 
         // identity_token 에서 추출한 데이터를 통해 멤버 조회 OR 생성
-        Member findOrCreateMember = memberCommandUseCase.findOrCreateMember(appleMemberData);
+        Member findOrCreateMember = memberCommandUseCase.findOrCreateMember(appleMemberData, Provider.APPLE);
 
         // 데모데이용
         log.info("[애플 로그인 API] ( MemberId = {} ) 애플 로그인 API 진행완료", findOrCreateMember.getId());

--- a/src/main/java/umc/plantory/domain/member/converter/MemberConverter.java
+++ b/src/main/java/umc/plantory/domain/member/converter/MemberConverter.java
@@ -82,13 +82,13 @@ public class MemberConverter {
                 .build();
     }
 
-    public static Member toMember (MemberDataDTO.MemberData kakaoMemberData) {
+    public static Member toMember (MemberDataDTO.MemberData kakaoMemberData, Provider provider) {
         return Member.builder()
                 .email(kakaoMemberData.getEmail())
                 .nickname(DEFAULT_NICKNAME)
                 .userCustomId(DEFAULT_USER_CUSTOM_ID)
                 .profileImgUrl(DEFAULT_PROFILE_IMG_URL)
-                .provider(Provider.KAKAO)
+                .provider(provider)
                 .providerId(kakaoMemberData.getSub())
                 .gender(Gender.NONE) // 다시 추가
                 .status(MemberStatus.PENDING)

--- a/src/main/java/umc/plantory/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/plantory/domain/member/service/MemberCommandService.java
@@ -29,6 +29,7 @@ import umc.plantory.global.enums.MemberStatus;
 
 import java.util.List;
 import umc.plantory.domain.term.entity.Term;
+import umc.plantory.global.enums.Provider;
 
 @Slf4j
 @Service
@@ -294,16 +295,16 @@ public class MemberCommandService implements MemberCommandUseCase {
      * id_token 에서 추출한 멤버 데이터를 통해
      * 기존 회원이라면 조회해서 가져오고
      * 첫 로그인이면 데이터 저장하는 메서드
-     * @param kakaoMemberData : id_token 에서 추출한 멤버 데이터
+     * @param memberData : id_token 에서 추출한 멤버 데이터
      * @return : 추출한 멤버 데이터와 일치하는 멤버
      */
     @Override
     @Transactional
-    public Member findOrCreateMember(MemberDataDTO.MemberData memberData) {
+    public Member findOrCreateMember(MemberDataDTO.MemberData memberData, Provider provider) {
         return memberRepository.findByProviderId(memberData.getSub())
                 .orElseGet(() -> {
                     // 새 멤버 생성
-                    Member createdMember = memberRepository.save(MemberConverter.toMember(memberData));
+                    Member createdMember = memberRepository.save(MemberConverter.toMember(memberData, provider));
                     Flower defaultFlower = flowerRepository.findByEmotion(Emotion.DEFAULT);
                     // 새 테라리움 생성
                     terrariumRepository.save(TerrariumConverter.toTerrarium(createdMember, defaultFlower));

--- a/src/main/java/umc/plantory/domain/member/service/MemberCommandUseCase.java
+++ b/src/main/java/umc/plantory/domain/member/service/MemberCommandUseCase.java
@@ -4,6 +4,7 @@ import umc.plantory.domain.member.dto.MemberDataDTO;
 import umc.plantory.domain.member.entity.Member;
 import umc.plantory.domain.member.dto.MemberRequestDTO;
 import umc.plantory.domain.member.dto.MemberResponseDTO;
+import umc.plantory.global.enums.Provider;
 
 public interface MemberCommandUseCase {
     MemberResponseDTO.TermAgreementResponse termAgreement(String authorization, MemberRequestDTO.TermAgreementRequest request);
@@ -11,5 +12,5 @@ public interface MemberCommandUseCase {
     MemberResponseDTO.ProfileUpdateResponse updateProfile(String authorization, MemberRequestDTO.ProfileUpdateRequest request);
     void logout(String authorization);
     void delete(String authorization);
-    Member findOrCreateMember(MemberDataDTO.MemberData memberData);
+    Member findOrCreateMember(MemberDataDTO.MemberData memberData, Provider provider);
 }


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약
- 애플로그인 시 provider 값이 APPLE 이 아닌 KAKAO 가 입력되는 에러 해결

## 🔗 2. 관련 이슈
- Closes #147 

## 🛠 3. 구현 내용 및 상세
- 애플로그인 시 provider 값이 APPLE 이 아닌 KAKAO 가 입력되는 에러 해결

## 📋 4. 리뷰 요구사항


## 💬 5. 참고 사항 
- 
