### PR TITLE
[#153] 일기 AI 코멘트 기능 및 비동기 이벤트 처리 적용

### DIFF
--- a/src/main/java/umc/plantory/PlantoryApplication.java
+++ b/src/main/java/umc/plantory/PlantoryApplication.java
@@ -3,11 +3,13 @@ package umc.plantory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableScheduling
+@EnableAsync
 public class PlantoryApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/umc/plantory/domain/diary/converter/DiaryConverter.java
+++ b/src/main/java/umc/plantory/domain/diary/converter/DiaryConverter.java
@@ -33,7 +33,7 @@ public class DiaryConverter {
                 .build();
     }
 
-    public static DiaryResponseDTO.DiaryInfoDTO toDiaryInfoDTO(Diary diary, String imageUrl) {
+    public static DiaryResponseDTO.DiaryInfoDTO toDiaryInfoDTO(Diary diary, String imageUrl, String aiComment) {
         return DiaryResponseDTO.DiaryInfoDTO.builder()
                 .diaryId(diary.getId())
                 .diaryDate(diary.getDiaryDate())
@@ -42,6 +42,7 @@ public class DiaryConverter {
                 .content(diary.getContent())
                 .diaryImgUrl(imageUrl)
                 .status(diary.getStatus())
+                .aiComment(aiComment != null ? aiComment : "")
                 .build();
     }
 

--- a/src/main/java/umc/plantory/domain/diary/converter/DiaryConverter.java
+++ b/src/main/java/umc/plantory/domain/diary/converter/DiaryConverter.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public class DiaryConverter {
 
-    public static Diary toDiary(DiaryRequestDTO.DiaryUploadDTO request, Member member, String title) {
+    public static Diary toDiary(DiaryRequestDTO.DiaryUploadDTO request, Member member, String title, String aiComment) {
         return Diary.builder()
                 .title(title)
                 .diaryDate(request.getDiaryDate())
@@ -23,6 +23,7 @@ public class DiaryConverter {
                 .sleepEndTime(request.getSleepEndTime())
                 .status(DiaryStatus.valueOf(request.getStatus()))
                 .member(member)
+                .aiComment(aiComment)
                 .build();
     }
 
@@ -33,7 +34,7 @@ public class DiaryConverter {
                 .build();
     }
 
-    public static DiaryResponseDTO.DiaryInfoDTO toDiaryInfoDTO(Diary diary, String imageUrl, String aiComment) {
+    public static DiaryResponseDTO.DiaryInfoDTO toDiaryInfoDTO(Diary diary, String imageUrl) {
         return DiaryResponseDTO.DiaryInfoDTO.builder()
                 .diaryId(diary.getId())
                 .diaryDate(diary.getDiaryDate())
@@ -42,7 +43,7 @@ public class DiaryConverter {
                 .content(diary.getContent())
                 .diaryImgUrl(imageUrl)
                 .status(diary.getStatus())
-                .aiComment(aiComment != null ? aiComment : "")
+                .aiComment(diary.getAiComment())
                 .build();
     }
 

--- a/src/main/java/umc/plantory/domain/diary/dto/DiaryResponseDTO.java
+++ b/src/main/java/umc/plantory/domain/diary/dto/DiaryResponseDTO.java
@@ -24,6 +24,7 @@ public class DiaryResponseDTO {
         private String content;
         private String diaryImgUrl;
         private DiaryStatus status;
+        private String aiComment;
     }
 
     @Builder

--- a/src/main/java/umc/plantory/domain/diary/entity/Diary.java
+++ b/src/main/java/umc/plantory/domain/diary/entity/Diary.java
@@ -45,6 +45,9 @@ public class Diary extends BaseEntity {
     @Column(length = 300)
     private String content;
 
+    @Column(length = 500)
+    private String aiComment;
+
     private LocalDateTime sleepEndTime;
 
     private LocalDateTime sleepStartTime;

--- a/src/main/java/umc/plantory/domain/diary/entity/Diary.java
+++ b/src/main/java/umc/plantory/domain/diary/entity/Diary.java
@@ -91,4 +91,9 @@ public class Diary extends BaseEntity {
     public void updateDeletedAt(LocalDateTime deletedAt) {
         this.deletedAt = deletedAt;
     }
+
+    public void updateTitleAndComment(String title, String aiComment) {
+        this.title = title;
+        this.aiComment = aiComment;
+    }
 }

--- a/src/main/java/umc/plantory/domain/diary/entity/Diary.java
+++ b/src/main/java/umc/plantory/domain/diary/entity/Diary.java
@@ -68,7 +68,8 @@ public class Diary extends BaseEntity {
                        String content,
                        LocalDateTime sleepStartTime,
                        LocalDateTime sleepEndTime,
-                       DiaryStatus status) {
+                       DiaryStatus status,
+                       String aiComment) {
 
         this.emotion = emotion;
         this.title = title;
@@ -76,6 +77,7 @@ public class Diary extends BaseEntity {
         this.sleepStartTime = sleepStartTime;
         this.sleepEndTime = sleepEndTime;
         this.status = status;
+        this.aiComment = aiComment;
     }
 
     public void updateStatus(DiaryStatus status) {

--- a/src/main/java/umc/plantory/domain/diary/event/DiaryAiEvent.java
+++ b/src/main/java/umc/plantory/domain/diary/event/DiaryAiEvent.java
@@ -1,0 +1,10 @@
+package umc.plantory.domain.diary.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class DiaryAiEvent {
+    private final Long diaryId;
+}

--- a/src/main/java/umc/plantory/domain/diary/event/DiaryAiEventListener.java
+++ b/src/main/java/umc/plantory/domain/diary/event/DiaryAiEventListener.java
@@ -1,0 +1,78 @@
+package umc.plantory.domain.diary.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import umc.plantory.domain.diary.entity.Diary;
+import umc.plantory.domain.diary.repository.DiaryRepository;
+import umc.plantory.global.ai.AIClient;
+import umc.plantory.global.ai.PromptFactory;
+import umc.plantory.global.apiPayload.code.status.ErrorStatus;
+import umc.plantory.global.apiPayload.exception.handler.DiaryHandler;
+import java.util.Objects;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DiaryAiEventListener {
+    private final DiaryRepository diaryRepository;
+    private final AIClient aiClient;
+
+    @Async
+    @EventListener(DiaryAiEvent.class)
+    @Transactional
+    public void handleDiaryAiEvent(DiaryAiEvent event) {
+
+        Diary diary = diaryRepository.findById(event.getDiaryId())
+                .orElseThrow(() -> new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
+
+        // 새로 추가될 제목, 코멘트
+        // 현재 상태로 미리 초기화
+        String newTitle = diary.getTitle();
+        String newAiComment = diary.getAiComment();
+
+        boolean needsUpdate = false;
+
+        // 상태 유무 판단은 DiaryCommandService에서 수행 -> 현재 diary는 모두 NORMAL 상태
+        // NORMAL 상태의 일기이지만 제목이 "임시 제목"일 경우 AI 제목 새로 생성
+        if (Objects.equals("임시 제목", diary.getTitle()) && diary.getContent() != null &&
+            !diary.getContent().isBlank()) {
+            newTitle = generateDiaryTitle(diary.getContent());
+            needsUpdate = true;
+        }
+
+        // NORMAL 상태의 일기이지만 AI 코멘트가 없을 경우 새로 생성
+        if (Objects.equals(diary.getAiComment(), "임시 코멘트")) {
+            newAiComment = generateDiaryComment(diary, newTitle);
+            needsUpdate = true;
+        }
+
+        if (needsUpdate) {
+            diary.updateTitleAndComment(newTitle, newAiComment);
+        }
+
+    }
+
+    // 프롬프트 생성 및 AI 호출 후, 제목 응답 받기
+    private String generateDiaryTitle(String content) {
+        Prompt prompt = PromptFactory.buildDiaryTitlePrompt(content);
+        return aiClient.getResponse(prompt);
+    }
+
+
+    // 프롬프트 생성 및 AI 호출 후, 코멘트 응답 받기
+    private String generateDiaryComment(Diary diary, String title) {
+        Prompt prompt = PromptFactory.buildDiaryCommentPrompt(
+                diary.getContent(),
+                title,
+                diary.getEmotion() != null ? diary.getEmotion().name() : null,
+                diary.getSleepStartTime(),
+                diary.getSleepEndTime()
+        );
+        return aiClient.getResponse(prompt);
+    }
+}

--- a/src/main/java/umc/plantory/domain/diary/service/DiaryCommandService.java
+++ b/src/main/java/umc/plantory/domain/diary/service/DiaryCommandService.java
@@ -126,10 +126,14 @@ public class DiaryCommandService implements DiaryCommandUseCase {
         }
 
         // 일기 본문 변경 시, 제목 다시 생성
-        String title = request.getContent() != null ? generateDiaryTitle(content) : diary.getTitle();
+        String diaryTitle = request.getContent() != null ? generateDiaryTitle(content) : diary.getTitle();
+
+        // 일기 본문 변경 시, 코멘트 재생성
+        String aiComment = generateDiaryComment(request.getContent(), diaryTitle, request.getEmotion(),
+                request.getSleepStartTime(), request.getSleepEndTime());
 
         // 일기, 이미지 업데이트 처리
-        diary.update(emotion, title, content, sleepStart, sleepEnd, status);
+        diary.update(emotion, diaryTitle, content, sleepStart, sleepEnd, status, aiComment);
         String diaryImgUrl = handleDiaryImage(diary, request.getDiaryImgUrl(), Boolean.TRUE.equals(request.getIsImgDeleted()));
 
         // TEMP 상태일 경우 tempSavedAt 기록

--- a/src/main/java/umc/plantory/domain/diary/service/DiaryCommandService.java
+++ b/src/main/java/umc/plantory/domain/diary/service/DiaryCommandService.java
@@ -85,7 +85,10 @@ public class DiaryCommandService implements DiaryCommandUseCase {
             diary.updateTempSavedAt(LocalDateTime.now());
         }
 
-        return DiaryConverter.toDiaryInfoDTO(diary, imageUrl);
+        // ai 코멘트 추가
+        String aiComment = "";
+
+        return DiaryConverter.toDiaryInfoDTO(diary, imageUrl, aiComment);
     }
 
     /**
@@ -140,7 +143,7 @@ public class DiaryCommandService implements DiaryCommandUseCase {
             handleWateringCan(diary, member);
         }
 
-        return DiaryConverter.toDiaryInfoDTO(diary, diaryImgUrl);
+        return DiaryConverter.toDiaryInfoDTO(diary, diaryImgUrl, "");
     }
 
     /**

--- a/src/main/java/umc/plantory/global/ai/PromptFactory.java
+++ b/src/main/java/umc/plantory/global/ai/PromptFactory.java
@@ -11,6 +11,7 @@ import umc.plantory.global.enums.Emotion;
 
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,6 +35,22 @@ public class PromptFactory {
         "꿈같은 하루", "혼자 걷는 밤거리" 같은 느낌의 짧고 자연스러운 문장을 사용해줘.
         제목:", "Title:" 같은 단어는 포함하지 말고, 내용만 반환해줘.
         """;
+    private static final String DIARY_COMMENT_SYSTEM_PROMPT = """
+        아래 정보를 참고해 한두 문장 정도의 간단한 코멘트를 작성해줘.
+        - 일기에서 인상 깊은 문장에 공감하거나 짧게 언급해줘.
+        - 감정을 반영해 따뜻하게 격려하거나 추천을 해줘.
+        - 수면 패턴이 눈에 띄면 간단히 언급해줘.
+        전체적으로 친근하고 긍정적인 톤을 유지해.
+        """;
+
+    private static final String DIARY_COMMENT_USER_PROMPT = """
+    일기 내용: %s
+    일기 제목: %s
+    감정: %s
+    잠든 시간: %s
+    기상 시간: %s
+    """;
+
 
     /**
      * OpenAI 모델 호출 시 사용할 옵션
@@ -99,5 +116,39 @@ public class PromptFactory {
                 .messages(systemMessage, userMessage)
                 .chatOptions(options)
                 .build();
+    }
+
+    // 유자가 작성한 일기에 AI 코멘트 생성을 위한 프롬프트 생성 메서드
+    public static Prompt buildDiaryCommentPrompt(String content, String title, String emotion, LocalDateTime sleepStartTime, LocalDateTime sleepEndTime) {
+        // DiaryComment 생성용 Prompt를 빌드하는 메서드
+        Message systemMessage = SystemMessage.builder()
+                .text(DIARY_COMMENT_SYSTEM_PROMPT)
+                .build();
+
+        // 유저 정보(일기 내용, 제목, 감정, 수면 시간)를 포함해 유저 프롬프트 텍스트 생성
+        String userText = getUserPromptContent(content, title, emotion, sleepStartTime, sleepEndTime);
+
+        // 생성한 유저 프롬프트 텍스트를 Message 객체로 생성
+        Message userMessage = UserMessage.builder()
+                .text(userText)
+                .build();
+
+        // 시스템 메시지와 유저 메시지를 포함한 Prompt 객체 생성 및 반환
+        return Prompt.builder()
+                .messages(userMessage)
+                .chatOptions(options)
+                .build();
+    }
+
+    // 유저 프롬프트에 쓸 문자열을 포맷팅해 생성하는 메서드
+    private static String getUserPromptContent(String content, String title, String emotion, LocalDateTime sleepStartTime, LocalDateTime sleepEndTime) {
+        String userText = String.format(DIARY_COMMENT_USER_PROMPT,
+                content,
+                title,
+                emotion != null ? emotion : "없음",
+                sleepStartTime != null ? sleepStartTime.toString() : "없음",
+                sleepEndTime != null ? sleepEndTime.toString() : "없음"
+        );
+        return userText;
     }
 }

--- a/src/main/java/umc/plantory/global/ai/PromptFactory.java
+++ b/src/main/java/umc/plantory/global/ai/PromptFactory.java
@@ -135,7 +135,7 @@ public class PromptFactory {
 
         // 시스템 메시지와 유저 메시지를 포함한 Prompt 객체 생성 및 반환
         return Prompt.builder()
-                .messages(userMessage)
+                .messages(systemMessage, userMessage)
                 .chatOptions(options)
                 .build();
     }


### PR DESCRIPTION
# 📌 Pull Request
구현 관련해서 노션에 자세하게 정리해놓았습니당
[노션 페이지](https://organic-ocean-98f.notion.site/API-275015e259408057af41fba8ce9928a1?source=copy_link)

## 📖 1. 변경 사항 요약
- "일기 작성 시 AI 코멘트 로직 추가"
- "AI API 호출 관련 비동기 이벤트 처리로 변경"

## 🔗 2. 관련 이슈
- refs #153 

## 🛠 3. 구현 내용 및 상세
1. DiaryAiEvent 및 DiaryAiEventListener 추가
   - `DiaryAiEvent`: diaryId를 담아 발행되는 이벤트 클래스를 신규 생성했습니다.
   - `DiaryAiEventListener`:
       - @EventListener를 통해 DiaryAiEvent를 구독하고, @Async를 사용하여 관련 로직을 비동기적으로 처리
       - 이벤트가 발생하면 diaryId로 일기를 조회한 뒤, 일기 내용/감정/수면 시간 등을 PromptFactory에 전달하여 AI 프롬프트를 생성
       - 생성된 프롬프트를 AIClient로 보내 AI 코멘트와 제목을 받아온 후, 해당 일기(Diary) 엔티티를 업데이트

  2. PromptFactory 변경 사항
   - buildDiaryCommentPrompt: 일기 내용, 제목, 감정, 수면 시간 등 여러 정보를 조합하여 코멘트를 생성하는 프롬프트를 제작

  3. DiaryCommandService 변경 사항
   - 동기적 AI 호출 로직 제거: 기존에 서비스 내에서 직접 AI를 호출하던 코드를 제거했습니다.
   - 이벤트 발행 로직 추가:
       - 일기 생성 (`saveDiary`): 일기 저장 시, 제목과 코멘트를 각각 "임시 제목", "임시 코멘트"로 우선 저장한 뒤 DiaryAiEvent를 발행합니다.
       - 일기 수정 (`updateDiary`): TEMP 상태에서 NORMAL 상태로 변경되거나, NORMAL 상태에서 내용이 수정될 때 DiaryAiEvent를 발행하여 AI가 새로운 내용에 맞춰 코멘트를 다시 생성

## 📋 4. 리뷰 요구사항
- DiaryCommandService 이벤트 처리 부분에서 기존 서비스 의도와 벗어난 코드가 있는 지 위주로 검사해주시면 감사하겠습니다

## 💬 5. 참고 사항 
